### PR TITLE
ReadonlyArray and ReadonlyRecord added

### DIFF
--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -1,0 +1,770 @@
+/**
+ * @since 0.10.0
+ */
+
+import {
+  Predicate,
+  constant,
+  pipe,
+  flow,
+  Endomorphism,
+  not,
+} from "fp-ts/function"
+import { Eq } from "fp-ts/Eq"
+import { Ord, ordNumber } from "fp-ts/Ord"
+import { ReadonlyNonEmptyArray } from "fp-ts/ReadonlyNonEmptyArray"
+import * as NEA from "fp-ts/ReadonlyNonEmptyArray"
+import { copy } from "fp-ts/Array"
+import * as RA from "fp-ts/ReadonlyArray"
+import * as R from "fp-ts/ReadonlyRecord"
+import { Option } from "fp-ts/Option"
+import * as O from "fp-ts/Option"
+import * as B from "fp-ts/boolean"
+import { reduceM } from "fp-ts/Foldable"
+import { fold, monoidProduct, monoidSum } from "fp-ts/Monoid"
+import { getJoinSemigroup, getMeetSemigroup } from "fp-ts/Semigroup"
+import { flip } from "./Function"
+
+/**
+ * Get the length of an array.
+ *
+ * @example
+ * import { length } from 'fp-ts-std/ReadonlyArray';
+ *
+ * assert.strictEqual(length(['a', 'b', 'c']), 3);
+ *
+ * @since 0.10.0
+ */
+export const length = (xs: ReadonlyArray<unknown>): number => xs.length
+
+/**
+ * Like `fp-ts/Array::elem`, but flipped.
+ *
+ * @example
+ * import { elemFlipped } from 'fp-ts-std/ReadonlyArray';
+ * import { eqString } from 'fp-ts/Eq';
+ *
+ * const isLowerVowel = elemFlipped(eqString)(['a', 'e', 'i', 'o', 'u']);
+ *
+ * assert.strictEqual(isLowerVowel('a'), true);
+ * assert.strictEqual(isLowerVowel('b'), false);
+ *
+ * @since 0.10.0
+ */
+export const elemFlipped = <A>(eq: Eq<A>) => (
+  xs: ReadonlyArray<A>,
+): Predicate<A> => y => RA.elem(eq)(y)(xs)
+
+/**
+ * Check if a predicate does not hold for any array member.
+ *
+ * import { none } from 'fp-ts-std/ReadonlyArray';
+ * import { Predicate } from 'fp-ts/function';
+ *
+ * const isFive: Predicate<number> = n => n === 5;
+ * const noneAreFive = none(isFive);
+ *
+ * assert.strictEqual(noneAreFive([4, 4, 4]), true);
+ * assert.strictEqual(noneAreFive([4, 5, 4]), false);
+ *
+ * @since 0.10.0
+ */
+export const none: <A>(f: Predicate<A>) => Predicate<ReadonlyArray<A>> = flow(
+  not,
+  RA.every,
+)
+
+/**
+ * Join an array of strings together into a single string using the supplied
+ * separator.
+ *
+ * @example
+ * import { join } from 'fp-ts-std/ReadonlyArray';
+ *
+ * const commaSepd = join(',');
+ *
+ * assert.strictEqual(commaSepd([]), '');
+ * assert.strictEqual(commaSepd(['a']), 'a');
+ * assert.strictEqual(commaSepd(['a', 'b', 'c']), 'a,b,c');
+ *
+ * @since 0.10.0
+ */
+export const join = (x: string) => (ys: ReadonlyArray<string>): string =>
+  ys.join(x)
+
+/**
+ * Like `fp-ts/Array::getEq`, but items are not required to be in the same
+ * order to determine equivalence. This function is therefore less efficient,
+ * and `getEq` should be preferred on ordered data.
+ *
+ * @example
+ * import { getEq } from 'fp-ts/Array';
+ * import { getDisorderedEq } from 'fp-ts-std/ReadonlyArray';
+ * import { ordNumber } from 'fp-ts/Ord';
+ *
+ * const f = getEq(ordNumber);
+ * const g = getDisorderedEq(ordNumber);
+ *
+ * assert.strictEqual(f.equals([1, 2, 3], [1, 3, 2]), false);
+ * assert.strictEqual(g.equals([1, 2, 3], [1, 3, 2]), true);
+ *
+ * @since 0.10.0
+ */
+export const getDisorderedEq = <A>(ordA: Ord<A>): Eq<ReadonlyArray<A>> => ({
+  equals: (xs: ReadonlyArray<A>, ys: ReadonlyArray<A>) => {
+    const sort = RA.sort(ordA)
+
+    return RA.getEq(ordA).equals(sort(xs), sort(ys))
+  },
+})
+
+/**
+ * Pluck the first item out of an array matching a predicate. Any further
+ * matches will be left untouched.
+ *
+ * This can be thought of as analagous to `fp-ts/Array::findFirst` where
+ * the remaining items, sans the match (if any), are returned as well.
+ *
+ * @example
+ * import { pluckFirst } from 'fp-ts-std/ReadonlyArray';
+ * import * as O from 'fp-ts/Option';
+ * import { Predicate } from 'fp-ts/function';
+ *
+ * const isOverFive: Predicate<number> = n => n > 5;
+ * const pluckFirstOverFive = pluckFirst(isOverFive);
+ *
+ * assert.deepStrictEqual(pluckFirstOverFive([1, 3, 5]), [O.none, [1, 3, 5]]);
+ * assert.deepStrictEqual(pluckFirstOverFive([1, 3, 5, 7, 9]), [O.some(7), [1, 3, 5, 9]]);
+ *
+ * @since 0.10.0
+ */
+export const pluckFirst = <A>(p: Predicate<A>) => (
+  xs: ReadonlyArray<A>,
+): [Option<A>, ReadonlyArray<A>] =>
+  pipe(
+    RA.findIndex(p)(xs),
+    O.fold(constant([O.none, xs]), i => [
+      O.some(xs[i]),
+      RA.unsafeDeleteAt(i, xs),
+    ]),
+  )
+
+/**
+ * Update an item in an array or, if it's not present yet, insert it.
+ *
+ * If the item exists more than once (as determined by the supplied `Eq`
+ * instance), only the first to be found will be updated. The order in which
+ * the array is checked is unspecified.
+ *
+ * @example
+ * import { upsert } from 'fp-ts-std/ReadonlyArray';
+ * import { eqString, contramap } from 'fp-ts/Eq';
+ *
+ * type Account = {
+ *     id: string;
+ *     name: string;
+ * };
+ *
+ * const eqAccount = contramap<string, Account>(acc => acc.id)(eqString);
+ *
+ * const accounts: ReadonlyArray<Account> = [{
+ *     id: 'a',
+ *     name: 'an account',
+ * }, {
+ *     id: 'b',
+ *     name: 'another account',
+ * }];
+ *
+ * const created: Account = {
+ *     id: 'c',
+ *     name: 'yet another account',
+ * };
+ *
+ * const updated: Account = {
+ *     id: 'b',
+ *     name: 'renamed account name',
+ * };
+ *
+ * const upsertAccount = upsert(eqAccount);
+ *
+ * assert.deepStrictEqual(upsertAccount(created)(accounts), [accounts[0], accounts[1], created]);
+ * assert.deepStrictEqual(upsertAccount(updated)(accounts), [accounts[0], updated]);
+ *
+ * @since 0.10.0
+ */
+export const upsert = <A>(eqA: Eq<A>) => (x: A) => (
+  ys: ReadonlyArray<A>,
+): ReadonlyNonEmptyArray<A> =>
+  pipe(
+    RA.findIndex<A>(y => eqA.equals(x, y))(ys),
+    O.map(i => RA.unsafeUpdateAt(i, x, ys)),
+    O.chain(NEA.fromReadonlyArray),
+    O.getOrElse(() => NEA.snoc(ys, x)),
+  )
+
+/**
+ * Insert all the elements of an array into another array at the specified
+ * index. Returns `None` if the index is out of bounds.
+ *
+ * The array of elements to insert must be non-empty.
+ *
+ * @example
+ * import { insertMany } from 'fp-ts-std/ReadonlyArray';
+ * import * as O from 'fp-ts/Option';
+ *
+ * const f = insertMany(1)(['a', 'b']);
+ * assert.deepStrictEqual(f([]), O.none);
+ * assert.deepStrictEqual(f(['x']), O.some(['x', 'a', 'b']));
+ * assert.deepStrictEqual(f(['x', 'y']), O.some(['x', 'a', 'b', 'y']));
+ *
+ * @since 0.5.0
+ */
+export const insertMany = (i: number) => <A>(xs: ReadonlyNonEmptyArray<A>) => (
+  ys: ReadonlyArray<A>,
+): Option<ReadonlyNonEmptyArray<A>> =>
+  pipe(
+    xs,
+    RA.reverse,
+    reduceM(O.Monad, RA.Foldable)(ys, (zs, x) => pipe(zs, RA.insertAt(i, x))),
+    O.chain(NEA.fromReadonlyArray),
+  )
+
+/**
+ * Filter a list, removing any elements that repeat that directly preceding
+ * them.
+ *
+ * @example
+ * import { dropRepeats } from 'fp-ts-std/ReadonlyArray';
+ * import { eqNumber } from 'fp-ts/Eq'
+ *
+ * assert.deepStrictEqual(dropRepeats(eqNumber)([1, 2, 2, 3, 2, 4, 4]), [1, 2, 3, 2, 4]);
+ *
+ * @since 0.10.0
+ */
+export const dropRepeats: <A>(
+  eq: Eq<A>,
+) => Endomorphism<ReadonlyArray<A>> = eq => xs =>
+  pipe(
+    xs,
+    RA.filterWithIndex((i, x) => i === 0 || !eq.equals(x, xs[i - 1])),
+  )
+
+/**
+ * Check if an array starts with the specified subarray.
+ *
+ * @example
+ * import { startsWith } from 'fp-ts-std/ReadonlyArray';
+ * import { eqString } from 'fp-ts/Eq'
+ *
+ * const startsXyz = startsWith(eqString)(['x', 'y', 'z']);
+ *
+ * assert.strictEqual(startsXyz(['x', 'y', 'z', 'a']), true);
+ * assert.strictEqual(startsXyz(['a', 'x', 'y', 'z']), false);
+ *
+ * @since 0.10.0
+ */
+export const startsWith = <A>(eq: Eq<A>) => (
+  start: ReadonlyArray<A>,
+): Predicate<ReadonlyArray<A>> =>
+  flow(RA.takeLeft(start.length), xs => RA.getEq(eq).equals(xs, start))
+
+/**
+ * Check if an array ends with the specified subarray.
+ *
+ * @example
+ * import { endsWith } from 'fp-ts-std/ReadonlyArray';
+ * import { eqString } from 'fp-ts/Eq'
+ *
+ * const endsXyz = endsWith(eqString)(['x', 'y', 'z']);
+ *
+ * assert.strictEqual(endsXyz(['a', 'x', 'y', 'z']), true);
+ * assert.strictEqual(endsXyz(['a', 'x', 'b', 'z']), false);
+ *
+ * @since 0.10.0
+ */
+export const endsWith = <A>(eq: Eq<A>) => (
+  end: ReadonlyArray<A>,
+): Predicate<ReadonlyArray<A>> =>
+  flow(RA.takeRight(end.length), xs => RA.getEq(eq).equals(xs, end))
+
+/**
+ * Returns a new array without the values present in the first input array.
+ *
+ * @example
+ * import { without } from 'fp-ts-std/ReadonlyArray';
+ * import { eqNumber } from 'fp-ts/Eq';
+ *
+ * const withoutFourOrFive = without(eqNumber)([4, 5]);
+ *
+ * assert.deepStrictEqual(withoutFourOrFive([3, 4]), [3]);
+ * assert.deepStrictEqual(withoutFourOrFive([4, 5]), []);
+ * assert.deepStrictEqual(withoutFourOrFive([4, 5, 6]), [6]);
+ * assert.deepStrictEqual(withoutFourOrFive([3, 4, 5, 6]), [3, 6]);
+ * assert.deepStrictEqual(withoutFourOrFive([4, 3, 4, 5, 6, 5]), [3, 6]);
+ *
+ * @since 0.10.0
+ */
+export const without = <A>(eq: Eq<A>) => (
+  xs: ReadonlyArray<A>,
+): Endomorphism<ReadonlyArray<A>> => flow(RA.filter(y => !RA.elem(eq)(y)(xs)))
+
+/**
+ * Returns the {@link https://en.wikipedia.org/wiki/Cartesian_product Cartesian product}
+ * of two arrays. In other words, returns an array containing tuples of every
+ * possible ordered combination of the two input arrays.
+ *
+ * @example
+ * import { cartesian } from 'fp-ts-std/ReadonlyArray';
+ *
+ * assert.deepStrictEqual(
+ *     cartesian([1, 2])(['a', 'b', 'c']),
+ *     [[1, 'a'], [1, 'b'], [1, 'c'], [2, 'a'], [2, 'b'], [2, 'c']],
+ * );
+ *
+ * @since 0.10.0
+ */
+export const cartesian = <A>(xs: ReadonlyArray<A>) => <B>(
+  ys: ReadonlyArray<B>,
+): ReadonlyArray<[A, B]> =>
+  pipe(
+    xs,
+    RA.chain(x =>
+      pipe(
+        ys,
+        RA.map(y => [x, y]),
+      ),
+    ),
+  )
+
+/**
+ * Adds together all the numbers in the input array.
+ *
+ * @example
+ * import { sum } from 'fp-ts-std/ReadonlyArray';
+ *
+ * assert.strictEqual(sum([]), 0);
+ * assert.strictEqual(sum([25, 3, 10]), 38);
+ *
+ * @since 0.10.0
+ */
+export const sum: (xs: ReadonlyArray<number>) => number = fold(monoidSum)
+
+/**
+ * Multiplies together all the numbers in the input array.
+ *
+ * @example
+ * import { product } from 'fp-ts-std/ReadonlyArray';
+ *
+ * assert.strictEqual(product([]), 1);
+ * assert.strictEqual(product([5]), 5);
+ * assert.strictEqual(product([4, 2, 3]), 24);
+ *
+ * @since 0.10.0
+ */
+export const product: (xs: ReadonlyArray<number>) => number = fold(
+  monoidProduct,
+)
+
+/**
+ * Calculate the mean of an array of numbers.
+ *
+ * @example
+ * import { mean } from 'fp-ts-std/ReadonlyArray';
+ *
+ * assert.deepStrictEqual(mean([2, 7, 9]), 6);
+ *
+ * @since 0.10.0
+ */
+export const mean = (xs: ReadonlyNonEmptyArray<number>): number =>
+  sum(xs) / xs.length
+
+/**
+ * Calculate the median of an array of numbers.
+ *
+ * @example
+ * import { median } from 'fp-ts-std/ReadonlyArray';
+ *
+ * assert.deepStrictEqual(median([2, 9, 7]), 7);
+ * assert.deepStrictEqual(median([7, 2, 10, 9]), 8);
+ *
+ * @since 0.10.0
+ */
+export const median: (xs: ReadonlyNonEmptyArray<number>) => number = flow(
+  NEA.sort(ordNumber),
+  xs => {
+    const i = xs.length / 2
+    return i % 1 === 0 ? (xs[i - 1] + xs[i]) / 2 : xs[Math.floor(i)]
+  },
+)
+
+/**
+ * Returns an array of tuples of the specified length occupied by consecutive
+ * elements.
+ *
+ * If `n` is not a positive number, an empty array is returned.
+ *
+ * If `n` is greater than the length of the array, an empty array is returned.
+ *
+ * @example
+ * import { aperture } from 'fp-ts-std/ReadonlyArray';
+ *
+ * assert.deepStrictEqual(aperture(1)([1, 2, 3, 4]), [[1], [2], [3], [4]]);
+ * assert.deepStrictEqual(aperture(2)([1, 2, 3, 4]), [[1, 2], [2, 3], [3, 4]]);
+ * assert.deepStrictEqual(aperture(3)([1, 2, 3, 4]), [[1, 2, 3], [2, 3, 4]]);
+ * assert.deepStrictEqual(aperture(4)([1, 2, 3, 4]), [[1, 2, 3, 4]]);
+ *
+ * @since 0.10.0
+ */
+export const aperture = (n: number) => <A>(
+  xs: ReadonlyArray<A>,
+): ReadonlyArray<ReadonlyArray<A>> => {
+  const go = (i: number) => (
+    ys: ReadonlyArray<ReadonlyArray<A>>,
+  ): ReadonlyArray<ReadonlyArray<A>> =>
+    i + n > xs.length ? ys : go(i + 1)(RA.snoc(ys, slice(i)(n + i)(xs)))
+
+  return n < 1 ? [] : go(0)([])
+}
+
+/**
+ * Returns the elements of the array between the start index (inclusive) and the
+ * end index (exclusive).
+ *
+ * This is merely a functional wrapper around `Array.prototype.slice`.
+ *
+ * @example
+ * import { slice } from 'fp-ts-std/ReadonlyArray';
+ *
+ * const xs = ['a', 'b', 'c', 'd'];
+ *
+ * assert.deepStrictEqual(slice(1)(3)(xs), ['b', 'c']);
+ * assert.deepStrictEqual(slice(1)(Infinity)(xs), ['b', 'c', 'd']);
+ * assert.deepStrictEqual(slice(0)(-1)(xs), ['a', 'b', 'c']);
+ * assert.deepStrictEqual(slice(-3)(-1)(xs), ['b', 'c']);
+ *
+ * @since 0.10.0
+ */
+export const slice = (start: number) => (end: number) => <A>(
+  xs: ReadonlyArray<A>,
+): ReadonlyArray<A> => xs.slice(start, end)
+
+/**
+ * Filters out items in the array for which the predicate holds. This can be
+ * thought of as the inverse of ordinary array filtering.
+ *
+ * @example
+ * import { reject } from 'fp-ts-std/ReadonlyArray';
+ * import { Predicate } from 'fp-ts/function';
+ *
+ * const isEven: Predicate<number> = n => n % 2 === 0;
+ *
+ * assert.deepStrictEqual(reject(isEven)([1, 2, 3, 4]), [1, 3]);
+ *
+ * @since 0.10.0
+ */
+export const reject = <A>(f: Predicate<A>): Endomorphism<ReadonlyArray<A>> =>
+  RA.filter(not(f))
+
+/**
+ * Move an item at index `from` to index `to`. See also `moveTo`.
+ *
+ * If either index is out of bounds, `None` is returned.
+ *
+ * If both indices are the same, the array is returned unchanged.
+ *
+ * @example
+ * import { moveFrom } from 'fp-ts-std/ReadonlyArray';
+ * import * as O from 'fp-ts/Option';
+ *
+ * assert.deepStrictEqual(moveFrom(0)(1)(['a', 'b', 'c']), O.some(['b', 'a', 'c']));
+ * assert.deepStrictEqual(moveFrom(1)(1)(['a', 'b', 'c']), O.some(['a', 'b', 'c']));
+ * assert.deepStrictEqual(moveFrom(0)(0)([]), O.none);
+ * assert.deepStrictEqual(moveFrom(0)(1)(['a']), O.none);
+ * assert.deepStrictEqual(moveFrom(1)(0)(['a']), O.none);
+ *
+ * @since 0.10.0
+ */
+export const moveFrom = (from: number) => (to: number) => <A>(
+  xs: ReadonlyArray<A>,
+): Option<ReadonlyArray<A>> =>
+  from >= xs.length || to >= xs.length
+    ? O.none
+    : from === to
+    ? O.some(xs)
+    : pipe(
+        xs,
+        RA.lookup(from),
+        O.chain(x => pipe(RA.deleteAt(from)(xs), O.chain(RA.insertAt(to, x)))),
+      )
+
+/**
+ * Move an item at index `from` to index `to`. See also `moveFrom`.
+ *
+ * If either index is out of bounds, `None` is returned.
+ *
+ * If both indices are the same, the array is returned unchanged.
+ *
+ * @example
+ * import { moveTo } from 'fp-ts-std/ReadonlyArray';
+ * import * as O from 'fp-ts/Option';
+ *
+ * assert.deepStrictEqual(moveTo(1)(0)(['a', 'b', 'c']), O.some(['b', 'a', 'c']));
+ * assert.deepStrictEqual(moveTo(1)(1)(['a', 'b', 'c']), O.some(['a', 'b', 'c']));
+ * assert.deepStrictEqual(moveTo(0)(0)([]), O.none);
+ * assert.deepStrictEqual(moveTo(0)(1)(['a']), O.none);
+ * assert.deepStrictEqual(moveTo(1)(0)(['a']), O.none);
+ *
+ * @since 0.10.0
+ */
+export const moveTo = flip(moveFrom)
+
+/**
+ * Map each item of an array to a key, and count how many map to each key.
+ *
+ * @example
+ * import { countBy } from 'fp-ts-std/ReadonlyArray';
+ * import { toLower } from 'fp-ts-std/String';
+ *
+ * const f = countBy(toLower);
+ * const xs = ['A', 'b', 'C', 'a', 'e', 'A'];
+ *
+ * assert.deepStrictEqual(f(xs), { a: 3, b: 1, c: 1, e: 1 });
+ *
+ * @since 0.10.0
+ */
+export const countBy = <A>(f: (x: A) => string) => (
+  xs: ReadonlyArray<A>,
+): Record<string, number> =>
+  R.fromFoldableMap(monoidSum, RA.Foldable)(xs, x => [f(x), 1])
+
+/**
+ * Remove the longest initial subarray from the end of the input array for
+ * which all elements satisfy the specified predicate, creating a new array.
+ *
+ * @example
+ * import { dropRightWhile } from 'fp-ts-std/ReadonlyArray';
+ * import { Predicate } from 'fp-ts/function';
+ *
+ * const isEven: Predicate<number> = n => n % 2 === 0;
+ * const dropRightEvens = dropRightWhile(isEven);
+ *
+ * assert.deepStrictEqual(dropRightEvens([6, 7, 3, 4, 2]), [6, 7, 3]);
+ *
+ * @since 0.10.0
+ */
+export const dropRightWhile = <A>(
+  f: Predicate<A>,
+): Endomorphism<ReadonlyArray<A>> =>
+  flow(RA.reverse, RA.dropLeftWhile(f), RA.reverse)
+
+/**
+ * Drop a number of elements from the specified index an array, returning a
+ * new array.
+ *
+ * If `i` is out of bounds, `None` will be returned.
+ *
+ * If `i` is a float, it will be rounded down to the nearest integer.
+ *
+ * If `n` is larger than the available number of elements from the provided
+ * index, only the elements prior to said index will be returned.
+ *
+ * If `n` is not a positive number, the array will be returned whole.
+ *
+ * If `n` is a float, it will be rounded down to the nearest integer.
+ *
+ * @example
+ * import { dropAt } from 'fp-ts-std/ReadonlyArray';
+ * import * as O from 'fp-ts/Option';
+ *
+ * assert.deepStrictEqual(dropAt(2)(0)(['a', 'b', 'c', 'd', 'e', 'f', 'g']), O.some(['a', 'b', 'c', 'd', 'e', 'f', 'g']));
+ * assert.deepStrictEqual(dropAt(2)(3)(['a', 'b', 'c', 'd', 'e', 'f', 'g']), O.some(['a', 'b', 'f', 'g']));
+ * assert.deepStrictEqual(dropAt(2)(Infinity)(['a', 'b', 'c', 'd', 'e', 'f', 'g']), O.some(['a', 'b']));
+ *
+ * @since 0.10.0
+ */
+
+export const dropAt = (i: number) => (n: number) => <A>(
+  xs: ReadonlyArray<A>,
+): Option<ReadonlyArray<A>> =>
+  pipe(
+    RA.isOutOfBound(i, xs),
+    B.fold(
+      () =>
+        pipe(
+          copy(Array.from(xs)),
+          ys => {
+            // eslint-disable-next-line functional/immutable-data, functional/no-expression-statement
+            ys.splice(i, n)
+            return ys
+          },
+          O.some,
+        ),
+      constant(O.none),
+    ),
+  )
+
+/**
+ * Tranposes the rows and columns of a 2D list. If some of the rows are shorter
+ * than the following rows, their elements are skipped.
+ *
+ * @example
+ * import { transpose } from 'fp-ts-std/ReadonlyArray';
+ *
+ * assert.deepStrictEqual(transpose([[1, 2, 3], [4, 5, 6]]), [[1, 4], [2, 5], [3, 6]]);
+ * assert.deepStrictEqual(transpose([[1, 4], [2, 5], [3, 6]]), [[1, 2, 3], [4, 5, 6]]);
+ * assert.deepStrictEqual(transpose([[10, 11], [20], [], [30, 31,32]]), [[10, 20, 30], [11, 31], [32]]);
+ *
+ * @since 0.10.0
+ */
+export const transpose = <A>(
+  xs: ReadonlyArray<ReadonlyArray<A>>,
+): ReadonlyArray<ReadonlyArray<A>> => {
+  /* eslint-disable functional/no-conditional-statement */
+  if (RA.isEmpty(xs)) return []
+  if (RA.isEmpty(xs[0])) return transpose(RA.dropLeft(1)(xs))
+  /* eslint-enable functional/no-conditional-statement */
+
+  const [[y, ...ys], ...yss] = xs
+  const zs = [y, ...RA.filterMap(RA.head)(yss)]
+  const zss = [ys, ...RA.map(RA.dropLeft(1))(yss)]
+  return [zs, ...transpose(zss)]
+}
+
+/**
+ * Calculate the longest initial subarray from the end of the input array for
+ * which all elements satisfy the specified predicate, creating a new array.
+ *
+ * @example
+ * import { takeRightWhile } from 'fp-ts-std/ReadonlyArray';
+ * import { Predicate } from 'fp-ts/function';
+ *
+ * const isEven: Predicate<number> = n => n % 2 === 0;
+ * const takeRightEvens = takeRightWhile(isEven);
+ *
+ * assert.deepStrictEqual(takeRightEvens([6, 7, 3, 4, 2]), [4, 2]);
+ *
+ * @since 0.10.0
+ */
+export const takeRightWhile = <A>(
+  f: Predicate<A>,
+): Endomorphism<ReadonlyArray<A>> =>
+  flow(RA.reverse, RA.takeLeftWhile(f), RA.reverse)
+
+/**
+ * Creates an array of all values which are present in one of the two input
+ * arrays, but not both. The order is determined by the input arrays and
+ * duplicate values present only in one input array are maintained.
+ *
+ * @example
+ * import { symmetricDifference } from 'fp-ts-std/ReadonlyArray';
+ * import { eqNumber } from 'fp-ts/Eq';
+ *
+ * assert.deepStrictEqual(symmetricDifference(eqNumber)([1, 2, 3, 4])([3, 4, 5, 6]), [1, 2, 5, 6]);
+ * assert.deepStrictEqual(symmetricDifference(eqNumber)([1, 7, 7, 4, 3])([3, 4, 9, 6]), [1, 7, 7, 9, 6]);
+ *
+ * @since 0.10.0
+ */
+export const symmetricDifference = <A>(eq: Eq<A>) => (
+  xs: ReadonlyArray<A>,
+): Endomorphism<ReadonlyArray<A>> => ys =>
+  RA.getMonoid<A>().concat(RA.difference(eq)(ys)(xs), RA.difference(eq)(xs)(ys))
+
+/**
+ * Like ordinary array reduction, however this also takes a predicate that is
+ * evaluated before each step. If the predicate doesn't hold, the reduction
+ * short-circuits and returns the current accumulator value.
+ *
+ * @example
+ * import { reduceWhile } from 'fp-ts-std/ReadonlyArray';
+ * import { add } from 'fp-ts-std/Number';
+ * import { Predicate } from 'fp-ts/function';
+ *
+ * const isEven: Predicate<number> = n => n % 2 === 0;
+ * const reduceUntilOdd = reduceWhile(isEven);
+ *
+ * assert.strictEqual(reduceUntilOdd(add)(0)([2, 4, 6, 9, 10]), 12);
+ *
+ * @since 0.10.0
+ */
+export const reduceWhile = <A>(p: Predicate<A>) => <B>(
+  f: (x: A) => (y: B) => B,
+): ((x: B) => (ys: ReadonlyArray<A>) => B) => {
+  const go = (acc: B) => (ys: ReadonlyArray<A>): B =>
+    pipe(
+      NEA.fromReadonlyArray(ys),
+      O.filter(flow(NEA.head, p)),
+      O.fold(
+        constant(acc),
+        flow(NEA.uncons, ([z, zs]) => go(f(z)(acc))(zs)),
+      ),
+    )
+
+  return go
+}
+
+/**
+ * Like ordinary array reduction, however this also takes a predicate that is
+ * evaluated before each step. If the predicate doesn't hold, the reduction
+ * short-circuits and returns the current accumulator value.
+ *
+ * @example
+ * import { reduceRightWhile } from 'fp-ts-std/ReadonlyArray';
+ * import { add } from 'fp-ts-std/Number';
+ * import { Predicate } from 'fp-ts/function';
+ *
+ * const isEven: Predicate<number> = n => n % 2 === 0;
+ * const reduceRightUntilOdd = reduceRightWhile(isEven);
+ *
+ * assert.strictEqual(reduceRightUntilOdd(add)(0)([2, 4, 7, 8, 10]), 18);
+ *
+ * @since 0.10.0
+ */
+export const reduceRightWhile = <A>(p: Predicate<A>) => <B>(
+  f: (x: A) => (y: B) => B,
+) => (x: B): ((ys: ReadonlyArray<A>) => B) =>
+  flow(RA.reverse, reduceWhile(p)(f)(x))
+
+/**
+ * Obtain the minimum value from a non-empty array.
+ *
+ * @example
+ * import { minimum } from 'fp-ts-std/ReadonlyArray';
+ * import { ordNumber } from 'fp-ts/Ord';
+ *
+ * assert.strictEqual(minimum(ordNumber)([2, 3, 1, 5, 4]), 1);
+ *
+ * @since 0.10.0
+ */
+export const minimum: <A>(
+  ord: Ord<A>,
+) => (xs: ReadonlyNonEmptyArray<A>) => A = flow(getMeetSemigroup, NEA.fold)
+
+/**
+ * Obtain the maximum value from a non-empty array.
+ *
+ * @example
+ * import { maximum } from 'fp-ts-std/ReadonlyArray';
+ * import { ordNumber } from 'fp-ts/Ord';
+ *
+ * assert.strictEqual(maximum(ordNumber)([2, 3, 1, 5, 4]), 5);
+ *
+ * @since 0.10.0
+ */
+export const maximum: <A>(
+  ord: Ord<A>,
+) => (xs: ReadonlyNonEmptyArray<A>) => A = flow(getJoinSemigroup, NEA.fold)
+
+/**
+ * Append two arrays in terms of a semigroup. In effect, a functional wrapper
+ * around `Array.prototype.concat`.
+ *
+ * @example
+ * import { concat } from 'fp-ts-std/ReadonlyArray';
+ *
+ * assert.deepStrictEqual(concat([1, 2])([3, 4]), [1, 2, 3, 4]);
+ *
+ * @since 0.10.0
+ */
+export const concat = <A>(
+  xs: ReadonlyArray<A>,
+): Endomorphism<ReadonlyArray<A>> => ys => RA.getMonoid<A>().concat(xs, ys)

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -1,0 +1,181 @@
+/*
+ * @since 0.10.0
+ */
+import { Endomorphism, flow, not, Predicate } from "fp-ts/function"
+import { Option } from "fp-ts/Option"
+import * as RR from "fp-ts/ReadonlyRecord"
+import * as RA from "fp-ts/ReadonlyArray"
+import * as RT from "fp-ts/ReadonlyTuple"
+import { getLastSemigroup } from "fp-ts/Semigroup"
+
+/**
+ * Get the values from a `Record`.
+ *
+ * @example
+ * import { values } from 'fp-ts-std/ReadonlyRecord';
+ *
+ * const x = { a: 1, b: 'two' };
+ *
+ * assert.deepStrictEqual(values(x), [1, 'two']);
+ *
+ * @since 0.10.0
+ */
+export const values = <A>(x: RR.ReadonlyRecord<string, A>): ReadonlyArray<A> =>
+  Object.values(x)
+
+/**
+ * Like `lookup` from fp-ts, but flipped.
+ *
+ * @example
+ * import { lookupFlipped } from 'fp-ts-std/ReadonlyRecord';
+ * import * as A from 'fp-ts/Array';
+ *
+ * const x = { a: 1, b: 'two', c: [true] };
+ * const ks = ['a', 'c'];
+ *
+ * assert.deepStrictEqual(A.filterMap(lookupFlipped(x))(ks), [1, [true]]);
+ *
+ * @since 0.10.0
+ */
+export const lookupFlipped = <A>(x: RR.ReadonlyRecord<string, A>) => (
+  k: string,
+): Option<A> => RR.lookup(k)(x)
+
+/**
+ * Pick a set of keys from a `Record`. The value-level equivalent of the `Pick`
+ * type.
+ *
+ * @example
+ * import { pick } from 'fp-ts-std/ReadonlyRecord';
+ *
+ * type MyType = { a: number; b: string; c: ReadonlyArray<boolean> };
+ * const picked = pick<MyType>()(['a', 'c']);
+ *
+ * assert.deepStrictEqual(picked({ a: 1, b: 'two', c: [true] }), { a: 1, c: [true] });
+ *
+ * @since 0.10.0
+ */
+export const pick = <A>() => <K extends keyof A>(ks: ReadonlyArray<K>) => (
+  x: A,
+): Pick<A, K> => {
+  // I don't believe there's any reasonable way to model this sort of
+  // transformation in the type system without an assertion - at least here
+  // it's in a single reused place
+  const o = {} as Pick<A, K>
+
+  /* eslint-disable */
+  for (const k of ks) {
+    o[k] = x[k]
+  }
+  /* eslint-enable */
+
+  return o
+}
+
+/**
+ * Omit a set of keys from a `Record`. The value-level equivalent of the `Omit`
+ * type.
+ *
+ * @example
+ * import { omit } from 'fp-ts-std/ReadonlyRecord';
+ *
+ * const sansB = omit(['b']);
+ *
+ * assert.deepStrictEqual(sansB({ a: 1, b: 'two', c: [true] }), { a: 1, c: [true] });
+ *
+ * @since 0.10.0
+ */
+export const omit = <K extends string>(ks: ReadonlyArray<K>) => <
+  V,
+  A extends RR.ReadonlyRecord<K, V>
+>(
+  x: Partial<A>,
+): Omit<A, K> => {
+  const y = { ...x }
+
+  /* eslint-disable */
+  for (const k of ks) {
+    delete y[k]
+  }
+  /* eslint-enable */
+
+  return y as Omit<A, K>
+}
+
+/**
+ * Filters out key/value pairs in the record for which the predicate upon the
+ * value holds. This can be thought of as the inverse of ordinary record
+ * filtering.
+ *
+ * @example
+ * import { reject } from 'fp-ts-std/ReadonlyRecord';
+ * import { Predicate } from 'fp-ts/function';
+ *
+ * const isEven: Predicate<number> = n => n % 2 === 0;
+ *
+ * assert.deepStrictEqual(reject(isEven)({ a: 1, b: 2, c: 3, d: 4 }), { a: 1, c: 3 });
+ *
+ * @since 0.10.0
+ */
+export const reject = <A>(
+  f: Predicate<A>,
+): Endomorphism<RR.ReadonlyRecord<string, A>> => RR.filter(not(f))
+
+/**
+ * Merge two records together. For merging many identical records, instead
+ * consider defining a semigroup.
+ *
+ * @example
+ * import { merge } from 'fp-ts-std/ReadonlyRecord';
+ *
+ * assert.deepStrictEqual(merge({ a: 1, b: 2 })({ b: 'two', c: true }), { a: 1, b: 'two', c: true });
+ *
+ * @since 0.10.0
+ */
+export const merge = <A>(x: A) => <B>(y: B): A & B => ({ ...x, ...y })
+
+/**
+ * Invert a record, keeping only the last value should the same key be
+ * encountered more than once. If you'd like to keep the values that would be
+ * lost, see instead `invertAll`.
+ *
+ * @example
+ * import { invertLast } from 'fp-ts-std/ReadonlyRecord';
+ * import { fromNumber } from 'fp-ts-std/String';
+ *
+ * assert.deepStrictEqual(invertLast(fromNumber)({ a: 1, b: 2, c: 2, d: 3 }), { '1': 'a', '2': 'c', '3': 'd' });
+ *
+ * @since 0.10.0
+ */
+export const invertLast = <A>(
+  f: (x: A) => string,
+): ((x: RR.ReadonlyRecord<string, A>) => RR.ReadonlyRecord<string, string>) =>
+  flow(
+    RR.toReadonlyArray,
+    RA.map(flow(RT.mapLeft(f), RT.swap)),
+    RR.fromFoldable(getLastSemigroup<string>(), RA.Foldable),
+  )
+
+/**
+ * Invert a record, collecting values with duplicate keys in an array. Should
+ * you only care about the last item or are not worried about the risk of
+ * duplicate keys, see instead `invertLast`.
+ *
+ * @example
+ * import { invertAll } from 'fp-ts-std/ReadonlyRecord';
+ * import { fromNumber } from 'fp-ts-std/String';
+ *
+ * assert.deepStrictEqual(invertAll(fromNumber)({ a: 1, b: 2, c: 2, d: 3 }), { '1': ['a'], '2': ['b', 'c'], '3': ['d'] });
+ *
+ * @since 0.10.0
+ */
+export const invertAll = <A>(
+  f: (x: A) => string,
+): ((
+  x: RR.ReadonlyRecord<string, A>,
+) => RR.ReadonlyRecord<string, ReadonlyArray<string>>) =>
+  flow(
+    RR.toReadonlyArray,
+    RA.map(flow(RT.bimap(f, RA.of), RT.swap)),
+    RR.fromFoldable(RA.getMonoid<string>(), RA.Foldable),
+  )

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import * as json from "./JSON"
 import * as number from "./Number"
 import * as option from "./Option"
 import * as record from "./Record"
+import * as readonlyArray from "./ReadonlyArray"
+import * as readonlyRecord from "./ReadonlyRecord"
 import * as string from "./String"
 import * as task from "./Task"
 import * as url from "./URL"
@@ -65,6 +67,14 @@ export {
    * @since 0.5.1
    */
   record,
+  /**
+   * @since 0.10.0
+   */
+  readonlyArray,
+  /**
+   * @since 0.10.0
+   */
+  readonlyRecord,
   /**
    * @since 0.5.1
    */

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -1,0 +1,981 @@
+import {
+  length,
+  elemFlipped,
+  none,
+  join,
+  pluckFirst,
+  upsert,
+  getDisorderedEq,
+  insertMany,
+  dropRepeats,
+  startsWith,
+  endsWith,
+  without,
+  cartesian,
+  sum,
+  product,
+  aperture,
+  slice,
+  reject,
+  moveFrom,
+  moveTo,
+  countBy,
+  dropRightWhile,
+  mean,
+  median,
+  dropAt,
+  transpose,
+  takeRightWhile,
+  symmetricDifference,
+  reduceWhile,
+  reduceRightWhile,
+  minimum,
+  maximum,
+  concat,
+} from "../src/ReadonlyArray"
+import * as O from "fp-ts/Option"
+import * as A from "fp-ts/ReadonlyArray"
+import { contramap as eqContramap, eqNumber } from "fp-ts/Eq"
+import { contramap as ordContramap, max, ordNumber } from "fp-ts/Ord"
+import {
+  constant,
+  constFalse,
+  constTrue,
+  flow,
+  identity,
+  pipe,
+  Predicate,
+} from "fp-ts/function"
+import fc from "fast-check"
+import { fold, monoidSum } from "fp-ts/Monoid"
+import { split } from "../src/String"
+import { ReadonlyNonEmptyArray } from "fp-ts/ReadonlyNonEmptyArray"
+import { values } from "../src/Record"
+import { add } from "../src/Number"
+import { NonEmptyArray } from "fp-ts/NonEmptyArray"
+
+describe("Array", () => {
+  describe("length", () => {
+    const f = length
+
+    it("returns length of array", () => {
+      expect(f([])).toBe(0)
+      expect(f([1, 2, 3])).toBe(3)
+    })
+
+    it("returned value is always non-negative", () => {
+      fc.assert(fc.property(fc.array(fc.anything()), xs => f(xs) >= 0))
+    })
+  })
+
+  describe("elemFlipped", () => {
+    const f = elemFlipped(eqNumber)
+
+    it("finds the element", () => {
+      expect(f([])(0)).toBe(false)
+      expect(f([1, 2, 3])(2)).toBe(true)
+      expect(f([1, 2, 3])(4)).toBe(false)
+    })
+  })
+
+  describe("none", () => {
+    const f = none<number>(n => n === 5)
+
+    it("returns true for empty input array", () => {
+      expect(f([])).toBe(true)
+    })
+
+    it("returns true if all predicates fail", () => {
+      expect(f([4])).toBe(true)
+      expect(f([4, 6])).toBe(true)
+    })
+
+    it("returns false if any predicates succeed", () => {
+      expect(f([5])).toBe(false)
+      expect(f([4, 5])).toBe(false)
+    })
+  })
+
+  describe("join", () => {
+    const delim = ","
+    const f = join(delim)
+
+    it("joins", () => {
+      expect(f([])).toBe("")
+      expect(f(["x"])).toBe("x")
+      expect(f(["x", "yz"])).toBe("x,yz")
+
+      fc.assert(
+        fc.property(fc.array(fc.string()), xs => {
+          const countDelims = flow(
+            split(""),
+            A.filter(c => c === delim),
+            length,
+          )
+
+          const countDelimsA = flow(A.map(countDelims), fold(monoidSum))
+
+          return (
+            countDelims(f(xs)) ===
+            countDelimsA(xs) + max(ordNumber)(0, length(xs) - 1)
+          )
+        }),
+      )
+    })
+  })
+
+  describe("pluckFirst", () => {
+    const p: Predicate<number> = x => x % 2 === 1
+    const f = pluckFirst(p)
+
+    it("finds the item", () => {
+      expect(f([2, 3, 4])).toEqual([O.some(3), [2, 4]])
+    })
+
+    it('does not "find" an incorrect item', () => {
+      expect(f([2, 4, 6])).toEqual([O.none, [2, 4, 6]])
+    })
+
+    it("removes only the first, left-most match", () => {
+      expect(f([2, 3, 4, 5])).toEqual([O.some(3), [2, 4, 5]])
+    })
+
+    it("does not mutate input", () => {
+      const xs = [2, 3, 4]
+      // eslint-disable-next-line functional/no-expression-statement
+      f(xs)
+      expect(xs).toEqual([2, 3, 4])
+    })
+  })
+
+  describe("upsert", () => {
+    type Thing = { id: number; name: string }
+    const eqThing = eqContramap<number, Thing>(x => x.id)(eqNumber)
+
+    const x1: Thing = { id: 1, name: "x" }
+    const x2: Thing = { id: 1, name: "x2" }
+    const y: Thing = { id: 2, name: "y" }
+    const z: Thing = { id: 3, name: "z" }
+
+    const f = upsert
+    const g = f(eqThing)(x2)
+
+    it("appends non-present item", () => {
+      expect(g([])).toEqual([x2])
+      expect(g([y, z])).toEqual([y, z, x2])
+    })
+
+    it("updates present item in-place", () => {
+      expect(g([x1, y])).toEqual([x2, y])
+      expect(g([y, x1])).toEqual([y, x2])
+    })
+
+    it("does not mutate input", () => {
+      const xs = [{ ...x1 }]
+      // eslint-disable-next-line functional/no-expression-statement
+      g(xs)
+      expect(xs).toEqual([{ ...x1 }])
+    })
+
+    it("always returns a non-empty array", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer()),
+          fc.integer(),
+          (xs, y) => !!f(eqNumber)(y)(xs).length,
+        ),
+      )
+    })
+  })
+
+  describe("getDisorderedEq", () => {
+    type Thing = { id: number; name: string }
+    const ordThing = ordContramap<number, Thing>(x => x.id)(ordNumber)
+
+    const y: Thing = { id: 1, name: "x" }
+    const z: Thing = { id: 2, name: "y" }
+    const zAlt: Thing = { id: 2, name: "changed" }
+
+    const f = getDisorderedEq(ordThing).equals
+
+    it("its equality using Eq", () => {
+      expect(f([], [])).toBe(true)
+      expect(f([y], [y])).toBe(true)
+      expect(f([z], [zAlt])).toBe(true)
+      expect(f([y, z], [y, z])).toBe(true)
+      expect(f([y, y], [y, z])).toBe(false)
+      expect(f([y, y], [y])).toBe(false)
+    })
+
+    it("disregards initial indices", () => {
+      expect(f([y, z], [z, y])).toBe(true)
+    })
+  })
+
+  describe("insertMany", () => {
+    const f = insertMany
+    const g = f(1)(["a", "b"])
+
+    it("returns None if index is out of bounds", () => {
+      expect(g([])).toEqual(O.none)
+    })
+
+    it("returns updated array wrapped in Some if index is okay", () => {
+      expect(f(0)(["x"])([])).toEqual(O.some(["x"]))
+      expect(g(["x"])).toEqual(O.some(["x", "a", "b"]))
+      expect(g(["x", "y"])).toEqual(O.some(["x", "a", "b", "y"]))
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything(), 1, 5) as fc.Arbitrary<NonEmptyArray<unknown>>,
+          fc.integer(0, 10),
+          (xs, i) => O.isSome(f(i)(xs)(xs)) === i <= length(xs),
+        ),
+      )
+
+      fc.assert(
+        fc.property(fc.array(fc.string(), 1, 20), xs =>
+          expect(pipe(g(xs), O.map(length))).toEqual(O.some(length(xs) + 2)),
+        ),
+      )
+    })
+
+    it("does not mutate input", () => {
+      const xs: ReadonlyNonEmptyArray<number> = [1, 2, 3]
+      const ys: ReadonlyNonEmptyArray<number> = [4, 5]
+      const zs = f(1)(ys)(xs)
+
+      expect(xs).toEqual([1, 2, 3])
+      expect(ys).toEqual([4, 5])
+      expect(zs).toEqual(O.some([1, 4, 5, 2, 3]))
+    })
+  })
+
+  describe("dropRepeats", () => {
+    const f = dropRepeats(eqNumber)
+
+    it("removes consecutive duplicates if any", () => {
+      expect(f([])).toEqual([])
+      expect(f([1, 2, 3])).toEqual([1, 2, 3])
+      expect(f([1, 2, 2, 3, 2, 4, 4])).toEqual([1, 2, 3, 2, 4])
+    })
+
+    it("never returns a larger array", () => {
+      fc.assert(
+        fc.property(fc.array(fc.integer()), xs => f(xs).length <= length(xs)),
+      )
+    })
+
+    it("never introduces new elements", () => {
+      const g = A.uniq(eqNumber)
+
+      fc.assert(
+        fc.property(fc.array(fc.integer()), xs =>
+          pipe(xs, f, g, A.every(elemFlipped(eqNumber)(g(xs)))),
+        ),
+      )
+    })
+  })
+
+  describe("startsWith", () => {
+    const f = startsWith(eqNumber)
+
+    it("returns true for empty subarray", () => {
+      fc.assert(fc.property(fc.array(fc.integer()), xs => f([])(xs)))
+    })
+
+    it("checks start of array for subarray", () => {
+      expect(f([1])([1, 2, 3])).toBe(true)
+      expect(f([3])([1, 2, 3])).toBe(false)
+
+      fc.assert(
+        fc.property(fc.array(fc.integer()), fc.array(fc.integer()), (xs, ys) =>
+          f(xs)(xs.concat(ys)),
+        ),
+      )
+    })
+  })
+
+  describe("endsWith", () => {
+    const f = endsWith(eqNumber)
+
+    it("returns true for empty subarray", () => {
+      fc.assert(fc.property(fc.array(fc.integer()), xs => f([])(xs)))
+    })
+
+    it("checks end of array for subarray", () => {
+      expect(f([3])([1, 2, 3])).toBe(true)
+      expect(f([1])([1, 2, 3])).toBe(false)
+
+      fc.assert(
+        fc.property(fc.array(fc.integer()), fc.array(fc.integer()), (xs, ys) =>
+          f(xs)(ys.concat(xs)),
+        ),
+      )
+    })
+  })
+
+  describe("without", () => {
+    const f = without(eqNumber)
+
+    it("removes numbers present in first input array", () => {
+      const g = f([4, 5])
+
+      expect(g([3, 4])).toEqual([3])
+      expect(g([4, 5])).toEqual([])
+      expect(g([4, 5, 6])).toEqual([6])
+      expect(g([3, 4, 5, 6])).toEqual([3, 6])
+      expect(g([4, 3, 4, 5, 6, 5])).toEqual([3, 6])
+
+      fc.assert(
+        fc.property(fc.array(fc.integer()), xs =>
+          expect(f(xs)(xs)).toEqual(A.empty),
+        ),
+      )
+    })
+  })
+
+  describe("cartesian", () => {
+    const f = cartesian
+
+    it("returns the Cartesian product", () => {
+      expect(f([1, 2])(["a", "b", "c"])).toEqual([
+        [1, "a"],
+        [1, "b"],
+        [1, "c"],
+        [2, "a"],
+        [2, "b"],
+        [2, "c"],
+      ])
+    })
+
+    it("output array length is the product of input array lengths", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything()),
+          fc.array(fc.anything()),
+          (xs, ys) => f(xs)(ys).length === length(xs) * ys.length,
+        ),
+      )
+    })
+  })
+
+  describe("sum", () => {
+    const f = sum
+
+    it("returns addition identity (zero) for empty input", () => {
+      expect(f([])).toBe(0)
+    })
+
+    it("sums non-empty input", () => {
+      expect(f([25, 3, 10])).toBe(38)
+      expect(f([-3, 2])).toBe(-1)
+      expect(f([2.5, 3.2])).toBe(5.7)
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer()),
+          xs => f(xs) === xs.reduce((acc, val) => acc + val, 0),
+        ),
+      )
+    })
+  })
+
+  describe("product", () => {
+    const f = product
+
+    it("returns multiplication identity (one) for empty input", () => {
+      expect(f([])).toBe(1)
+    })
+
+    it("calculates product of non-empty input", () => {
+      expect(f([4, 2, 3])).toBe(24)
+      expect(f([5])).toBe(5)
+      expect(f([1.5, -5])).toBe(-7.5)
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer()),
+          xs => f(xs) === xs.reduce((acc, val) => acc * val, 1),
+        ),
+      )
+    })
+  })
+
+  describe("aperture", () => {
+    const f = aperture
+
+    it("returns empty array for empty array input", () => {
+      expect(f(0)([])).toEqual([])
+
+      fc.assert(fc.property(fc.integer(0, 100), n => !f(n)([]).length))
+    })
+
+    it("returns empty array for non-positive input number", () => {
+      fc.assert(
+        fc.property(
+          fc.integer(0),
+          fc.array(fc.anything()),
+          (n, xs) => !f(n)(xs).length,
+        ),
+      )
+    })
+
+    it("returns empty array for tuple length larger than input array length", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything()),
+          xs => !f(length(xs) + 1)(xs).length,
+        ),
+      )
+    })
+
+    it("returns array of tuples of consecutive items", () => {
+      expect(f(1)([1, 2, 3, 4])).toEqual([[1], [2], [3], [4]])
+      expect(f(2)([1, 2, 3, 4])).toEqual([
+        [1, 2],
+        [2, 3],
+        [3, 4],
+      ])
+      expect(f(3)([1, 2, 3, 4])).toEqual([
+        [1, 2, 3],
+        [2, 3, 4],
+      ])
+      expect(f(4)([1, 2, 3, 4])).toEqual([[1, 2, 3, 4]])
+    })
+
+    it("output length is input length - n + 1", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything()),
+          fc.integer(1, 100),
+          (xs, n) => f(n)(xs).length === max(ordNumber)(0, length(xs) - n + 1),
+        ),
+      )
+    })
+  })
+
+  describe("slice", () => {
+    const f = slice
+
+    it("behaves identically to Array.prototype.slice", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything()),
+          fc.integer(),
+          fc.integer(),
+          (xs, start, end) =>
+            expect(f(start)(end)(xs)).toEqual(xs.slice(start, end)),
+        ),
+      )
+    })
+  })
+
+  describe("reject", () => {
+    const p: Predicate<number> = n => n % 2 === 0
+    const f = reject(p)
+
+    it("filters out items for which the predicate holds", () => {
+      expect(f([1, 2, 3, 4])).toEqual([1, 3])
+    })
+
+    it("is the inverse of filter", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer()),
+          xs => A.filter(p)(xs).length + f(xs).length === length(xs),
+        ),
+      )
+    })
+  })
+
+  describe("moveFrom", () => {
+    const f = moveFrom
+
+    it("returns unmodified array provided same indices (in bounds)", () => {
+      const n = 10
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything(), 1, n),
+          fc.integer(0, n - 1),
+          (xs, i) => i >= length(xs) || expect(f(i)(i)(xs)).toEqual(O.some(xs)),
+        ),
+      )
+    })
+
+    it("returns None if source is out of bounds", () => {
+      fc.assert(
+        fc.property(fc.array(fc.anything()), xs =>
+          expect(f(length(xs))(0)(xs)).toEqual(O.none),
+        ),
+      )
+    })
+
+    it("returns None if target is out of bounds", () => {
+      fc.assert(
+        fc.property(fc.array(fc.anything()), xs =>
+          expect(f(0)(length(xs))(xs)).toEqual(O.none),
+        ),
+      )
+    })
+
+    it("moves source to target", () => {
+      expect(f(0)(1)(["a", "b", "c"])).toEqual(O.some(["b", "a", "c"]))
+      expect(f(1)(0)(["a", "b", "c"])).toEqual(O.some(["b", "a", "c"]))
+
+      const n = 10
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything(), n, n),
+          fc.integer(0, n - 1),
+          fc.integer(0, n - 1),
+          (xs, i, j) => O.isSome(f(i)(j)(xs)),
+        ),
+      )
+    })
+
+    it("returns the same array size", () => {
+      const n = 10
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything(), n, n),
+          fc.integer(0, n - 1),
+          fc.integer(0, n - 1),
+          (xs, i, j) =>
+            pipe(
+              f(i)(j)(xs),
+              O.exists(ys => length(ys) === n),
+            ),
+        ),
+      )
+    })
+
+    it("sibling indices are interchangeable", () => {
+      const n = 10
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything(), n, n),
+          fc.integer(0, n - 2),
+          (xs, i) => expect(f(i)(i + 1)(xs)).toEqual(f(i + 1)(i)(xs)),
+        ),
+      )
+    })
+  })
+
+  describe("moveTo", () => {
+    const f = moveTo
+
+    it("returns unmodified array provided same indices (in bounds)", () => {
+      const n = 10
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything(), 1, n),
+          fc.integer(0, n - 1),
+          (xs, i) => i >= length(xs) || expect(f(i)(i)(xs)).toEqual(O.some(xs)),
+        ),
+      )
+    })
+
+    it("returns None if source is out of bounds", () => {
+      fc.assert(
+        fc.property(fc.array(fc.anything()), xs =>
+          expect(f(0)(length(xs))(xs)).toEqual(O.none),
+        ),
+      )
+    })
+
+    it("returns None if target is out of bounds", () => {
+      fc.assert(
+        fc.property(fc.array(fc.anything()), xs =>
+          expect(f(length(xs))(0)(xs)).toEqual(O.none),
+        ),
+      )
+    })
+
+    it("moves source to target", () => {
+      expect(f(0)(1)(["a", "b", "c"])).toEqual(O.some(["b", "a", "c"]))
+      expect(f(1)(0)(["a", "b", "c"])).toEqual(O.some(["b", "a", "c"]))
+
+      const n = 10
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything(), n, n),
+          fc.integer(0, n - 1),
+          fc.integer(0, n - 1),
+          (xs, i, j) => O.isSome(f(i)(j)(xs)),
+        ),
+      )
+    })
+
+    it("returns the same array size", () => {
+      const n = 10
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything(), n, n),
+          fc.integer(0, n - 1),
+          fc.integer(0, n - 1),
+          (xs, i, j) =>
+            pipe(
+              f(i)(j)(xs),
+              O.exists(ys => length(ys) === n),
+            ),
+        ),
+      )
+    })
+
+    it("sibling indices are interchangeable", () => {
+      const n = 10
+
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything(), n, n),
+          fc.integer(0, n - 2),
+          (xs, i) => expect(f(i)(i + 1)(xs)).toEqual(f(i + 1)(i)(xs)),
+        ),
+      )
+    })
+  })
+
+  describe("countBy", () => {
+    const f = countBy
+
+    it("gets key from input function and counts", () => {
+      expect(f(constant("x"))(["a", "b", "c"])).toEqual({ x: 3 })
+      expect(f<string>(identity)(["a", "b", "c"])).toEqual({ a: 1, b: 1, c: 1 })
+    })
+
+    it("counts the same summed number as the length of the array", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.string()),
+          xs => pipe(xs, f(identity), values, sum) === xs.length,
+        ),
+      )
+    })
+
+    it("all numbers are above zero", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.string()),
+          flow(
+            f(identity),
+            values,
+            A.every(n => n > 0),
+          ),
+        ),
+      )
+    })
+  })
+
+  describe("dropRightWhile", () => {
+    const f = dropRightWhile
+
+    it("removes elements from the right until predicate fails", () => {
+      expect(f<string>(x => x === "a")(["a", "a", "b", "a", "a"])).toEqual([
+        "a",
+        "a",
+        "b",
+      ])
+    })
+
+    it("constTrue returns empty array", () => {
+      fc.assert(
+        fc.property(fc.array(fc.anything()), xs =>
+          expect(f(constTrue)(xs)).toEqual([]),
+        ),
+      )
+    })
+
+    it("constFalse returns original array", () => {
+      fc.assert(
+        fc.property(fc.array(fc.anything()), xs =>
+          expect(f(constFalse)(xs)).toEqual(xs),
+        ),
+      )
+    })
+  })
+
+  describe("mean", () => {
+    const f = mean
+
+    it("calculates the mean", () => {
+      expect(f([2, 7, 9])).toBe(6)
+
+      fc.assert(
+        fc.property(
+          fc.integer(1, 50),
+          fc.integer(),
+          (x, y) => f(A.replicate(x, y) as ReadonlyNonEmptyArray<number>) === y,
+        ),
+      )
+    })
+  })
+
+  describe("median", () => {
+    const f = median
+
+    it("calculates the median", () => {
+      expect(f([2, 9, 7])).toBe(7)
+      expect(f([7, 2, 10, 9])).toBe(8)
+
+      fc.assert(
+        fc.property(
+          fc.integer(1, 50),
+          fc.integer(),
+          (x, y) => f(A.replicate(x, y) as ReadonlyNonEmptyArray<number>) === y,
+        ),
+      )
+    })
+  })
+
+  describe("dropAt", () => {
+    const f = dropAt
+    const xs = ["a", "b", "c", "d", "e", "f", "g"]
+
+    it("removes elements from index", () => {
+      expect(f(2)(3)(xs)).toEqual(O.some(["a", "b", "f", "g"]))
+    })
+
+    it("removes everything from the index if count is too large", () => {
+      expect(f(2)(Infinity)(xs)).toEqual(O.some(["a", "b"]))
+    })
+
+    it("rounds down both input numbers", () => {
+      expect(f(1)(5)(xs)).toEqual(O.some(["a", "g"]))
+      expect(f(1.9)(5.9)(xs)).toEqual(O.some(["a", "g"]))
+    })
+
+    it("returns None if index out of bounds", () => {
+      expect(f(-1)(1)(xs)).toEqual(O.none)
+      expect(f(xs.length)(1)(xs)).toEqual(O.none)
+    })
+
+    it("returns input array if count is not positive", () => {
+      expect(f(2)(-1)(xs)).toEqual(O.some(xs))
+      expect(f(2)(0)(xs)).toEqual(O.some(xs))
+    })
+
+    it("does not mutate input", () => {
+      const ys = [1, 2, 3]
+      expect(f(1)(1)(ys)).toEqual(O.some([1, 3]))
+      expect(ys).toEqual([1, 2, 3])
+    })
+  })
+
+  describe("transpose", () => {
+    const f = transpose
+
+    it("transposes equal length arrays", () => {
+      expect(
+        f([
+          [1, 2, 3],
+          [4, 5, 6],
+        ]),
+      ).toEqual([
+        [1, 4],
+        [2, 5],
+        [3, 6],
+      ])
+
+      expect(
+        f([
+          [1, 4],
+          [2, 5],
+          [3, 6],
+        ]),
+      ).toEqual([
+        [1, 2, 3],
+        [4, 5, 6],
+      ])
+    })
+
+    it("transposes unequal length arrays", () => {
+      expect(f([[10, 11], [20], [], [30, 31, 32]])).toEqual([
+        [10, 20, 30],
+        [11, 31],
+        [32],
+      ])
+    })
+
+    it("maintains same flattened size", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.array(fc.anything())),
+          xs => length(A.flatten(xs)) === length(A.flatten(f(xs))),
+        ),
+      )
+    })
+
+    it("does not mistakenly pass along undefined values", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.array(fc.anything().filter(x => x !== undefined))),
+          flow(
+            f,
+            A.flatten,
+            A.every(x => x !== undefined),
+          ),
+        ),
+      )
+    })
+  })
+
+  describe("takeRightWhile", () => {
+    const f = takeRightWhile
+
+    it("takes elements from the right until predicate fails", () => {
+      expect(f<string>(x => x !== "c")(["a", "b", "c", "d", "e"])).toEqual([
+        "d",
+        "e",
+      ])
+    })
+
+    it("constTrue returns original array", () => {
+      fc.assert(
+        fc.property(fc.array(fc.anything()), xs =>
+          expect(f(constTrue)(xs)).toEqual(xs),
+        ),
+      )
+    })
+
+    it("constFalse returns empty array", () => {
+      fc.assert(
+        fc.property(fc.array(fc.anything()), xs =>
+          expect(f(constFalse)(xs)).toEqual([]),
+        ),
+      )
+    })
+  })
+
+  describe("symmetricDifference", () => {
+    const f = symmetricDifference(eqNumber)
+
+    it("returns unique values from both arrays", () => {
+      expect(f([1, 2, 3, 4])([3, 4, 5, 6])).toEqual([1, 2, 5, 6])
+      expect(f([1, 2, 3, 4, 3])([4, 3, 4, 5, 6])).toEqual([1, 2, 5, 6])
+    })
+
+    it("returns the items ordered by input array order", () => {
+      expect(f([1, 7, 4, 3])([3, 4, 9, 6])).toEqual([1, 7, 9, 6])
+    })
+
+    it("keeps duplicates", () => {
+      expect(f([1, 7, 7, 4, 3])([3, 4, 9, 6])).toEqual([1, 7, 7, 9, 6])
+    })
+
+    it("two empty inputs gives empty output", () => {
+      expect(f([])([])).toEqual([])
+    })
+
+    it("one empty input returns other input whole", () => {
+      fc.assert(
+        fc.property(fc.array(fc.integer()), xs =>
+          expect(f(xs)([])).toEqual(xs),
+        ),
+      )
+
+      fc.assert(
+        fc.property(fc.array(fc.integer()), xs =>
+          expect(f([])(xs)).toEqual(xs),
+        ),
+      )
+    })
+  })
+
+  describe("reduceWhile", () => {
+    const f = reduceWhile
+
+    it("reduces until predicate fails", () => {
+      expect(f<number>(n => n !== 0)(add)(0)([1, 2, 0, 4, 5])).toBe(3)
+    })
+
+    it("reduces like normal with constTrue", () => {
+      expect(f<number>(constTrue)(add)(0)([1, 2, 3, 4])).toBe(10)
+    })
+
+    it("returns initial value with constFalse", () => {
+      expect(f<number>(constFalse)(add)(0)([1, 2, 3, 4])).toBe(0)
+    })
+  })
+
+  describe("reduceRightWhile", () => {
+    const f = reduceRightWhile
+
+    it("reduces from the right until predicate fails", () => {
+      expect(f<number>(n => n !== 0)(add)(0)([1, 2, 0, 4, 5])).toBe(9)
+    })
+
+    it("reduces like normal with constTrue", () => {
+      expect(f<number>(constTrue)(add)(0)([1, 2, 3, 4])).toBe(10)
+    })
+
+    it("returns initial value with constFalse", () => {
+      expect(f<number>(constFalse)(add)(0)([1, 2, 3, 4])).toBe(0)
+    })
+  })
+
+  describe("minimum", () => {
+    const f = minimum(ordNumber)
+
+    it("returns identity on singleton non-empty array", () => {
+      fc.assert(fc.property(fc.integer(), n => f([n]) === n))
+    })
+
+    it("returns the smallest value", () => {
+      expect(f([3, 1, 2])).toBe(1)
+
+      fc.assert(
+        fc.property(
+          fc.integer(),
+          n => f([n, n + 1]) === n && f([n + 1, n]) === n,
+        ),
+      )
+    })
+  })
+
+  describe("maximum", () => {
+    const f = maximum(ordNumber)
+
+    it("returns identity on singleton non-empty array", () => {
+      fc.assert(fc.property(fc.integer(), n => f([n]) === n))
+    })
+
+    it("returns the largest value", () => {
+      expect(f([1, 3, 2])).toBe(3)
+
+      fc.assert(
+        fc.property(
+          fc.integer(),
+          n => f([n, n + 1]) === n + 1 && f([n + 1, n]) === n + 1,
+        ),
+      )
+    })
+  })
+
+  describe("concat", () => {
+    const f = concat
+
+    it("concats", () => {
+      expect(f([1, 2])([3])).toEqual([1, 2, 3])
+      expect(f([1, [2]])([3])).toEqual([1, [2], 3])
+    })
+
+    it("obeys monoidal identity law", () => {
+      expect(f(A.empty)(A.empty)).toEqual(A.empty)
+
+      fc.assert(
+        fc.property(fc.array(fc.anything()), xs => {
+          expect(f<unknown>(A.empty)(xs)).toEqual(xs)
+          expect(f<unknown>(xs)(A.empty)).toEqual(xs)
+        }),
+      )
+    })
+  })
+})

--- a/test/ReadonlyRecord.ts
+++ b/test/ReadonlyRecord.ts
@@ -1,0 +1,186 @@
+import {
+  values,
+  lookupFlipped,
+  pick,
+  omit,
+  reject,
+  merge,
+  invertLast,
+  invertAll,
+} from "../src/ReadonlyRecord"
+import * as O from "fp-ts/Option"
+import * as RR from "fp-ts/ReadonlyRecord"
+import * as RA from "fp-ts/ReadonlyArray"
+import fc from "fast-check"
+import { flow, pipe, Predicate } from "fp-ts/function"
+import { fromNumber } from "../src/String"
+import { eqNumber, eqString } from "fp-ts/lib/Eq"
+
+describe("Record", () => {
+  describe("values", () => {
+    const f = values
+
+    it("gets object values", () => {
+      expect(f({})).toEqual([])
+      expect(f({ a: 1 })).toEqual([1])
+      expect(f({ a: 1, b: ["two"] })).toEqual([1, ["two"]])
+    })
+  })
+
+  describe("lookupFlipped", () => {
+    const f = lookupFlipped
+
+    it("cannot find anything in empty object", () => {
+      fc.assert(fc.property(fc.string(), x => O.isNone(f({})(x))))
+    })
+
+    it("finds matching key", () => {
+      expect(f({ a: 1 })("a")).toEqual(O.some(1))
+      expect(f({ a: ["two"], b: "a" })("a")).toEqual(O.some(["two"]))
+    })
+  })
+
+  describe("pick", () => {
+    type Thing = { name: string; age: number }
+    const x: Thing = { name: "Hodor", age: 123 }
+
+    it("picks no keys", () => {
+      expect(pick<Thing>()([])(x)).toEqual({})
+    })
+
+    it("picks individual keys", () => {
+      expect(pick<Thing>()(["name"])(x)).toEqual({ name: "Hodor" })
+      expect(pick<Thing>()(["age"])(x)).toEqual({ age: 123 })
+    })
+
+    it("picks multiple keys", () => {
+      expect(pick<Thing>()(["name", "age"])(x)).toEqual(x)
+    })
+  })
+
+  describe("omit", () => {
+    type Thing = { name: string; id: string; foo: string }
+
+    it("omits multiple keys", () => {
+      const before: Thing = { name: "Ragnor", id: "789", foo: "Bar" }
+      const after: Omit<Thing, "id" | "foo"> = { name: "Ragnor" }
+
+      expect(omit(["id", "foo"])(before)).toEqual(after)
+    })
+
+    it("typechecks missing keys", () => {
+      const before: Thing = { name: "Ragnor", id: "789", foo: "Bar" }
+      const after: Omit<Thing, "id"> = { name: "Ragnor", foo: "Bar" }
+
+      expect(omit(["id", "bar"])(before)).toEqual(after)
+    })
+  })
+
+  describe("reject", () => {
+    const p: Predicate<number> = n => n % 2 === 0
+    const f = reject(p)
+
+    it("filters out items for which the predicate holds", () => {
+      expect(f({ a: 1, b: 2, c: 3, d: 4 })).toEqual({ a: 1, c: 3 })
+    })
+
+    it("is the inverse of filter", () => {
+      fc.assert(
+        fc.property(
+          fc.dictionary(fc.string(), fc.integer()),
+          xs =>
+            pipe(xs, RR.filter(p), RR.size) + pipe(xs, f, RR.size) ===
+            RR.size(xs),
+        ),
+      )
+    })
+  })
+
+  describe("merge", () => {
+    const f = merge
+
+    it("merges, prioritising the second input", () => {
+      expect(f({ a: 1, b: 2 })({ b: "two", c: true })).toEqual({
+        a: 1,
+        b: "two",
+        c: true,
+      })
+    })
+  })
+
+  describe("invertLast", () => {
+    const f = invertLast
+
+    it("inverts", () => {
+      expect(f(fromNumber)({ a: 1, b: 2, c: 3 })).toEqual({
+        "1": "a",
+        "2": "b",
+        "3": "c",
+      })
+    })
+
+    it("keeps the last value for duplicate key", () => {
+      expect(f(fromNumber)({ a: 1, b: 2, c: 2, d: 3 })).toEqual({
+        "1": "a",
+        "2": "c",
+        "3": "d",
+      })
+    })
+
+    it("has every unique transformed value as a key", () => {
+      const g = fromNumber
+      const h: (
+        x: RR.ReadonlyRecord<string, number>,
+      ) => ReadonlyArray<string> = flow(values, RA.uniq(eqNumber), RA.map(g))
+
+      fc.assert(
+        fc.property(fc.dictionary(fc.string(), fc.integer()), x =>
+          pipe(x, f(g), RR.keys, ks =>
+            pipe(
+              h(x),
+              RA.every(k => RA.elem(eqString)(k)(ks)),
+            ),
+          ),
+        ),
+      )
+    })
+  })
+
+  describe("invertAll", () => {
+    const f = invertAll
+
+    it("inverts", () => {
+      expect(f(fromNumber)({ a: 1, b: 2, c: 3 })).toEqual({
+        "1": ["a"],
+        "2": ["b"],
+        "3": ["c"],
+      })
+    })
+
+    it("keeps the all values for duplicate key", () => {
+      expect(f(fromNumber)({ a: 1, b: 2, c: 2, d: 3 })).toEqual({
+        "1": ["a"],
+        "2": ["b", "c"],
+        "3": ["d"],
+      })
+    })
+
+    it("has every unique transformed value as a key", () => {
+      const g = fromNumber
+      const h: (
+        x: RR.ReadonlyRecord<string, number>,
+      ) => ReadonlyArray<string> = flow(values, RA.uniq(eqNumber), RA.map(g))
+
+      fc.assert(
+        fc.property(fc.dictionary(fc.string(), fc.integer()), x =>
+          pipe(x, f(g), RR.keys, ks =>
+            pipe(
+              h(x),
+              RA.every(k => RA.elem(eqString)(k)(ks)),
+            ),
+          ),
+        ),
+      )
+    })
+  })
+})


### PR DESCRIPTION
`fp-ts` is about to deprecate the mutable versions of `Array` and `Record` and totally remove them in Version 3.0.0. For easier preparation of projects that use `fp-ts-std` it would be helpful to have the readonly alternatives also in this library.