### PR TITLE
added splitAt for strings

### DIFF
--- a/src/String.ts
+++ b/src/String.ts
@@ -713,3 +713,17 @@ export const takeLeftWhile: (f: Predicate<string>) => Endomorphism<string> =
  */
 export const takeRightWhile: (f: Predicate<string>) => Endomorphism<string> =
   flow(takeRightWhileArr, under)
+
+/**
+ * Partition a string into parts at an index.
+ * Resulting parts can then be handled using fp-ts/Tuple.
+ *
+ * @example
+ *
+ * import { partitionAtIndex } from 'fp-ts-std/String';
+ *
+ * assert.deepStrictEqual(partitionAtIndex(1)("abc"), ["a", "bc"]);
+ */
+export const partitionAtIndex = (index: number) => (str: string) =>
+    [slice(0)(index)(str), slice(index)(Infinity)(str)]
+

--- a/src/String.ts
+++ b/src/String.ts
@@ -720,10 +720,10 @@ export const takeRightWhile: (f: Predicate<string>) => Endomorphism<string> =
  *
  * @example
  *
- * import { partitionAtIndex } from 'fp-ts-std/String';
+ * import { splitAt } from 'fp-ts-std/String';
  *
- * assert.deepStrictEqual(partitionAtIndex(1)("abc"), ["a", "bc"]);
+ * assert.deepStrictEqual(splitAt(1)("abc"), ["a", "bc"]);
  */
-export const partitionAtIndex = (index: number) => (str: string) =>
+export const splitAt = (index: number) => (str: string) =>
     [slice(0)(index)(str), slice(index)(Infinity)(str)]
 

--- a/test/String.ts
+++ b/test/String.ts
@@ -39,7 +39,7 @@ import {
   replaceAll,
   takeLeftWhile,
   takeRightWhile,
-  partitionAtIndex
+  splitAt,
 } from "../src/String"
 import * as O from "fp-ts/Option"
 import * as NEA from "fp-ts/NonEmptyArray"
@@ -886,19 +886,20 @@ describe("String", () => {
     })
   })
 
-  describe("partitionAtIndex", () => {
+  describe("splitAt", () => {
 
     it('"joining" results in the same string', () => {
       fc.assert(fc.property(fc.integer(), fc.string(), (index, str) =>
-        partitionAtIndex(index)(str).join("") === str
+        splitAt(index)(str).join("") === str
       ))
     })
 
     it("first and last elements are the same as splits at index", () => {
       fc.assert(fc.property(fc.integer(), fc.string(), (index, str) => {
-         const tuple = partitionAtIndex(index)(str);
+         const tuple = splitAt(index)(str);
          return tuple[0] === slice(0)(index)(str) && tuple[1] === slice(index)(Infinity)(str);
       }))
 
   })
 })
+});

--- a/test/String.ts
+++ b/test/String.ts
@@ -39,6 +39,7 @@ import {
   replaceAll,
   takeLeftWhile,
   takeRightWhile,
+  partitionAtIndex
 } from "../src/String"
 import * as O from "fp-ts/Option"
 import * as NEA from "fp-ts/NonEmptyArray"
@@ -883,5 +884,21 @@ describe("String", () => {
     it("returns empty string on constFalse", () => {
       fc.assert(fc.property(fc.string(), x => f(constFalse)(x) === ""))
     })
+  })
+
+  describe("partitionAtIndex", () => {
+
+    it('"joining" results in the same string', () => {
+      fc.assert(fc.property(fc.integer(), fc.string(), (index, str) =>
+        partitionAtIndex(index)(str).join("") === str
+      ))
+    })
+
+    it("first and last elements are the same as splits at index", () => {
+      fc.assert(fc.property(fc.integer(), fc.string(), (index, str) => {
+         const tuple = partitionAtIndex(index)(str);
+         return tuple[0] === slice(0)(index)(str) && tuple[1] === slice(index)(Infinity)(str);
+      }))
+
   })
 })


### PR DESCRIPTION
Convert a string into a Tuple by splitting it at an index.  Example:

```javascript
import * as t from "fp-ts/Tuple";
import { flow } from "fp-ts/function";
import { partitionAtIndex } from "fp-ts-std/String"

const capitalize = flow(
  partitionAtIndex(1),
  t.bimap(s.toLower, s.toUpper), // snd, first
  ([ x, y ]) => x + y
);
```