### PR TITLE
Fix Boolean (either, both) to be short circuiting

### DIFF
--- a/src/Boolean.ts
+++ b/src/Boolean.ts
@@ -4,10 +4,10 @@
  * @since 0.1.0
  */
 
-import { getSemigroup as getFunctionSemigroup } from "fp-ts/function"
 import { Predicate } from "fp-ts/Predicate"
 import { Endomorphism } from "fp-ts/Endomorphism"
 import { SemigroupAll, SemigroupAny } from "fp-ts/boolean"
+import { curry2T } from "./Function"
 
 /**
  * Invert a boolean.
@@ -118,7 +118,7 @@ export const anyPass =
     fs.some(f => f(x))
 
 /**
- * Combine two predicates under conjunction.
+ * Combine two predicates under conjunction in short-circuited fashion.
  *
  * @example
  * import { both } from 'fp-ts-std/Boolean';
@@ -134,13 +134,10 @@ export const anyPass =
  *
  * @since 0.5.0
  */
-export const both =
-  <A>(f: Predicate<A>): Endomorphism<Predicate<A>> =>
-  g =>
-    getFunctionSemigroup(SemigroupAll)<A>().concat(f, g)
+export const both = curry2T(allPass)
 
 /**
- * Combine two predicates under disjunction.
+ * Combine two predicates under disjunction in short-circuited fashion.
  *
  * @example
  * import { either } from 'fp-ts-std/Boolean';
@@ -156,7 +153,4 @@ export const both =
  *
  * @since 0.5.0
  */
-export const either =
-  <A>(f: Predicate<A>): Endomorphism<Predicate<A>> =>
-  g =>
-    getFunctionSemigroup(SemigroupAny)<A>().concat(f, g)
+export const either = curry2T(anyPass)

--- a/test/Boolean.ts
+++ b/test/Boolean.ts
@@ -104,6 +104,14 @@ describe("Boolean", () => {
     it("succeeds if both predicates succeed", () => {
       expect(f(6)).toBe(true)
     })
+
+    it("short circuiting if first predicate fails", () => {
+      const snd = jest.fn().mockImplementation(constTrue)
+      const g = both<number>(constFalse)(snd)
+
+      expect(g(8)).toBe(false)
+      expect(snd).not.toBeCalledWith(8)
+    })
   })
 
   describe("either", () => {
@@ -123,6 +131,14 @@ describe("Boolean", () => {
 
     it("succeeds if both predicates succeed", () => {
       expect(f(6)).toBe(true)
+    })
+
+    it("short circuiting if first predicate succeed", () => {
+      const snd = jest.fn().mockImplementation(constFalse)
+      const g = either<number>(constTrue)(snd)
+
+      expect(g(8)).toBe(true)
+      expect(snd).not.toBeCalledWith(8)
     })
   })
 })


### PR DESCRIPTION
Quote from **Ramda** docs:

> `both`: A function which calls the two provided functions and returns the && of the results. It returns the result of the first function if it is false-y and the result of the second function otherwise. **Note that this is short-circuited, meaning that the second function will not be invoked if the first returns a false-y value**.

> `either`: A function wrapping calls to the two functions in an || operation, returning the result of the first function if it is truth-y and the result of the second function otherwise. **Note that this is short-circuited, meaning that the second function will not be invoked if the first returns a truth-y value**.

Not sure this is idiomatic fixing, open to suggestions.