### PR TITLE
Align CJS main entrypoint and its index.d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This project adheres to semantic versioning.
 
-## 0.13.0 (_Unreleased_)
+## 0.13.0 (2021-12-16)
 
 - Add `Alternative` module.
 - Add `Isomorphism` module.

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "exports": {
+    ".": "./dist/cjs/index.js",
     "./*": {
       "require": "./dist/cjs/*.js",
       "import": "./dist/esm/*.js"
     }
   },
+  "types": "index.d.ts",
   "typesVersions": {
     "*": {
       "*": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fp-ts-std",
   "description": "The missing pseudo-standard library for fp-ts.",
-  "version": "0.13.0-beta.0",
+  "version": "0.13.0",
   "license": "MIT",
   "author": "Sam A. Horvath-Hunt <hello@samhh.com>",
   "repository": {


### PR DESCRIPTION
In order to supporting both:

```ts
import { number } from 'fp-ts-std'
```
or

```ts
const { number } = require('fp-ts-std')
```

Where supported prior to v0.12