### PR TITLE
fix: Record/pick returns non-existing properties

### DIFF
--- a/src/Record.ts
+++ b/src/Record.ts
@@ -69,15 +69,13 @@ export const pick =
     // I don't believe there's any reasonable way to model this sort of
     // transformation in the type system without an assertion - at least here
     // it's in a single reused place
-    const o = {} as Pick<A, K>
-
-    /* eslint-disable */
-    for (const k of ks) {
-      o[k] = x[k]
-    }
-    /* eslint-enable */
-
-    return o
+    return ks.reduce(
+      (memo, key) => ({
+        ...memo,
+        ...(key in x ? { [key]: x[key] } : {}),
+      }),
+      {},
+    ) as Pick<A, K>
   }
 
 /**

--- a/test/Record.ts
+++ b/test/Record.ts
@@ -44,8 +44,9 @@ describe("Record", () => {
   })
 
   describe("pick", () => {
-    type Thing = { name: string; age: number }
+    type Thing = { name: string; age: number; email?: string }
     const x: Thing = { name: "Hodor", age: 123 }
+    const y: Thing = { name: "Hodor", age: 123, email: "foo@bar.com" }
 
     it("picks no keys", () => {
       expect(pipe(x, pick([]))).toEqual({})
@@ -54,10 +55,13 @@ describe("Record", () => {
     it("picks individual keys", () => {
       expect(pipe(x, pick(["name"]))).toEqual({ name: "Hodor" })
       expect(pipe(x, pick(["age"]))).toEqual({ age: 123 })
+      expect(pipe(x, pick(["email"]))).toStrictEqual({})
+      expect(pipe(y, pick(["email"]))).toStrictEqual({ email: "foo@bar.com" })
     })
 
     it("picks multiple keys", () => {
-      expect(pipe(x, pick(["name", "age"]))).toEqual(x)
+      expect(pipe(x, pick(["name", "age", "email"]))).toStrictEqual(x)
+      expect(pipe(y, pick(["name", "age", "email"]))).toStrictEqual(y)
     })
   })
 


### PR DESCRIPTION
`Pick<{ foo?: number }, "foo">` yields `{ foo?: number }`. The current implementation of `Record/pick` returns value of type `{ foo: number | undefined }` actually, which means:

```
type Thing = { name: string; age: number; email?: string }
const x: Thing = { name: "Hodor", age: 123 }
console.log(pipe(x, pick(["email"])))
// { email: undefined }
```

This PR makes the behavior of `pick` respects its type definition.