### PR TITLE
Adds runReader, runReaderEither, runReaderTask, runReaderTaskEither

### DIFF
--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -1,0 +1,25 @@
+/**
+ * Utility functions to accommodate `fp-ts/Reader`.
+ *
+ * @since 0.15.0
+ */
+import { Reader } from "fp-ts/Reader"
+import { apply } from "fp-ts/function"
+
+/**
+ * Runs a Reader and extracts the final value from it.
+ *
+ * @example
+ * import { runReader } from 'fp-ts-std/Reader'
+ * import { pipe } from "fp-ts/function"
+ * import * as R from 'fp-ts/Reader'
+ *
+ * type Env = { dependency: string }
+ * const env: Env = { dependency: "dependency " }
+ * const extractedValue = pipe(R.of<Env, number>(1), runReader(env))
+ * assert.strictEqual(extractedValue, 1)
+ *
+ *
+ * @since 0.15.0
+ */
+export const runReader: <R, A>(r: R) => (reader: Reader<R, A>) => A = apply

--- a/src/ReaderEither.ts
+++ b/src/ReaderEither.ts
@@ -1,0 +1,35 @@
+/**
+ * Utility functions to accommodate `fp-ts/ReaderEither`.
+ *
+ * @since 0.15.0
+ */
+import { ReaderEither } from "fp-ts/ReaderEither"
+import { Either } from "fp-ts/Either"
+import { runReader } from "./Reader"
+
+/**
+ * Runs a ReaderEither and extracts the final Either from it.
+ *
+ * @example
+ * import { runReaderEither } from 'fp-ts-std/ReaderEither'
+ * import { pipe } from "fp-ts/function"
+ * import * as RE from "fp-ts/ReaderEither"
+ * import * as E from "fp-ts/Either"
+ *
+ * type Env = { dependency: string }
+ * const env: Env = { dependency: "dependency" }
+ *
+ * const extractedEither = pipe(
+ *  E.right(1),
+ *  RE.fromEither,
+ *  runReaderEither(env)
+ * )
+ *
+ * assert.deepStrictEqual(extractedEither, E.right(1))
+ *
+ *
+ * @since 0.15.0
+ */
+export const runReaderEither: <R, E, A>(
+  r: R,
+) => (reader: ReaderEither<R, E, A>) => Either<E, A> = runReader

--- a/src/ReaderTask.ts
+++ b/src/ReaderTask.ts
@@ -1,0 +1,30 @@
+/**
+ * Utility functions to accommodate `fp-ts/ReaderTask`.
+ *
+ * @since 0.15.0
+ */
+import { ReaderTask } from "fp-ts/ReaderTask"
+import { Task } from "fp-ts/Task"
+import { runReader } from "./Reader"
+
+/**
+ * Runs a ReaderTask and extracts the final Task from it.
+ *
+ * @example
+ * import { runReaderTask } from 'fp-ts-std/ReaderTask'
+ * import { pipe } from "fp-ts/function"
+ * import * as RT from "fp-ts/ReaderTask"
+ *
+ * type Env = { dependency: string }
+ * const env: Env = { dependency: "dependency " }
+ * pipe(
+ *  RT.of<Env, number>(1),
+ *  runReaderTask(env)
+ * )().then(extractedValue => assert.strictEqual(extractedValue, 1))
+ *
+ *
+ * @since 0.15.0
+ */
+export const runReaderTask: <R, A>(
+  r: R,
+) => (reader: ReaderTask<R, A>) => Task<A> = runReader

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -4,10 +4,36 @@
  * @since 0.14.3
  */
 import * as RTE from "fp-ts/ReaderTaskEither"
+import { TaskEither } from "fp-ts/TaskEither"
+import { runReader } from "./Reader"
 import {
   unsafeUnwrap as unsafeUnwrapTE,
   unsafeUnwrapLeft as unsafeUnwrapLeftTE,
 } from "./TaskEither"
+
+/**
+ * Runs a ReaderTaskEither and extracts the final TaskEither from it.
+ *
+ * @example
+ * import { runReaderTaskEither } from 'fp-ts-std/ReaderTaskEither'
+ * import { pipe } from "fp-ts/function"
+ * import * as RTE from "fp-ts/ReaderTaskEither"
+ * import * as E from "fp-ts/Either"
+ *
+ * type Env = { dependency: string }
+ * const env: Env = { dependency: "dependency" }
+ * pipe(
+ *  E.right(1),
+ *  RTE.fromEither,
+ *  runReaderTaskEither(env)
+ * )().then(extractedValue => assert.deepStrictEqual(extractedValue, E.right(1)))
+ *
+ *
+ * @since 0.15.0
+ */
+export const runReaderTaskEither: <R, E, A>(
+  r: R,
+) => (reader: RTE.ReaderTaskEither<R, E, A>) => TaskEither<E, A> = runReader
 
 /**
  * Unwrap the promise from within a `ReaderTaskEither`, rejecting with the inner

--- a/test/Reader.ts
+++ b/test/Reader.ts
@@ -1,0 +1,14 @@
+import { runReader } from "../src/Reader"
+import * as R from "fp-ts/Reader"
+import { pipe } from "fp-ts/function"
+
+describe("Reader", () => {
+  describe("runReader", () => {
+    type Env = { dependency: string }
+    it("extracts expected value from a Reader", () => {
+      const env: Env = { dependency: "dependency" }
+      const extractedValue = pipe(R.of<Env, number>(1), runReader(env))
+      return expect(extractedValue).toBe(1)
+    })
+  })
+})

--- a/test/ReaderEither.ts
+++ b/test/ReaderEither.ts
@@ -1,0 +1,39 @@
+import { runReaderEither } from "../src/ReaderEither"
+import * as RE from "fp-ts/ReaderEither"
+import * as E from "fp-ts/Either"
+import { pipe } from "fp-ts/function"
+import fc from "fast-check"
+
+describe("ReaderEither", () => {
+  describe("runReaderEither", () => {
+    it("extracts expected Either right from a ReaderEither", () => {
+      type Env = { dependency: string }
+      const env: Env = { dependency: "dependency " }
+      fc.assert(
+        fc.property(fc.integer(), _ => {
+          const re: RE.ReaderEither<Env, never, number> = pipe(
+            E.right(_),
+            RE.fromEither,
+          )
+          const extractedRight = pipe(re, runReaderEither(env))
+          expect(extractedRight).toStrictEqual(E.right(_))
+        }),
+      )
+    })
+
+    it("extracts expected Either left from a ReaderEither", () => {
+      type Env = { dependency: string }
+      const env: Env = { dependency: "dependency" }
+      fc.assert(
+        fc.property(fc.integer(), _ => {
+          const re: RE.ReaderEither<Env, number, never> = pipe(
+            E.left(_),
+            RE.fromEither,
+          )
+          const extractedLeft = pipe(re, runReaderEither(env))
+          expect(extractedLeft).toStrictEqual(E.left(_))
+        }),
+      )
+    })
+  })
+})

--- a/test/ReaderTask.ts
+++ b/test/ReaderTask.ts
@@ -1,0 +1,22 @@
+import { runReaderTask } from "../src/ReaderTask"
+import * as RT from "fp-ts/ReaderTask"
+import { pipe } from "fp-ts/function"
+import fc from "fast-check"
+
+describe("ReaderTask", () => {
+  describe("runReaderTask", () => {
+    it("extracts expected Task from a ReaderTask", async () => {
+      type Env = { dependency: string }
+      const env: Env = { dependency: "dependency" }
+      await fc.assert(
+        fc.asyncProperty(fc.integer(), async _ => {
+          const extractedTask = pipe(
+            RT.of<Env, number>(_),
+            runReaderTask(env),
+          )()
+          await expect(extractedTask).resolves.toBe(_)
+        }),
+      )
+    })
+  })
+})

--- a/test/ReaderTaskEither.ts
+++ b/test/ReaderTaskEither.ts
@@ -1,5 +1,12 @@
-import { unsafeUnwrap, unsafeUnwrapLeft } from "../src/ReaderTaskEither"
+import {
+  unsafeUnwrap,
+  unsafeUnwrapLeft,
+  runReaderTaskEither,
+} from "../src/ReaderTaskEither"
 import * as RTE from "fp-ts/ReaderTaskEither"
+import * as E from "fp-ts/Either"
+import { pipe } from "fp-ts/function"
+import fc from "fast-check"
 
 describe("ReaderTaskEither", () => {
   describe("unsafeUnwrap", () => {
@@ -23,6 +30,38 @@ describe("ReaderTaskEither", () => {
 
     it("rejects Right", () => {
       return expect(f(RTE.right("r"))({})).rejects.toBe("r")
+    })
+  })
+
+  describe("runReaderTaskEither", () => {
+    it("extracts expected TaskEither right from a ReaderTaskEither", async () => {
+      type Env = { dependency: string }
+      const env: Env = { dependency: "dependency " }
+      await fc.assert(
+        fc.asyncProperty(fc.integer(), async _ => {
+          const rte: RTE.ReaderTaskEither<Env, never, number> = pipe(
+            E.right(_),
+            RTE.fromEither,
+          )
+          const extractedRight = pipe(rte, runReaderTaskEither(env))()
+          await expect(extractedRight).resolves.toStrictEqual(E.right(_))
+        }),
+      )
+    })
+
+    it("extracts expected TaskEither left from a ReaderTaskEither", async () => {
+      type Env = { dependency: string }
+      const env: Env = { dependency: "dependency" }
+      await fc.assert(
+        fc.asyncProperty(fc.integer(), async _ => {
+          const rte: RTE.ReaderTaskEither<Env, number, never> = pipe(
+            E.left(_),
+            RTE.fromEither,
+          )
+          const extractedLeft = pipe(rte, runReaderTaskEither(env))()
+          await expect(extractedLeft).resolves.toStrictEqual(E.left(_))
+        }),
+      )
     })
   })
 })


### PR DESCRIPTION
Should solve https://github.com/samhh/fp-ts-std/issues/132

I would have liked to also cover `ReaderIO` but I guess it would make more sense to first update the version of `fp-ts` used by this library before implementing `runReaderIO` given that `ReaderIO` has recently landed in `fp-ts`. 😅 

