### PR TITLE
Support TypeScript nodenext module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,15 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "exports": {
-    ".": "./dist/cjs/index.js",
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js",
+      "types": "./dist/types/index.d.ts"
+    },
     "./*": {
       "require": "./dist/cjs/*.js",
-      "import": "./dist/esm/*.js"
+      "import": "./dist/esm/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "types": "index.d.ts",


### PR DESCRIPTION
When using `nodenext` module resolution and there's an `exports` in the package.json, it requires a `types` field or else fails to resolve modules.

This adds `types` to `exports/./*` to resolve types for `import etc from 'fp-ts-std/etc'`, and changes the `.` import to an object so that types are correctly resolved for `import { etc } from 'fp-ts-std'`. Not sure why it didn't have an ESM import for `.` already, so added that too.

[Related TS issue](https://github.com/microsoft/TypeScript/issues/49388)