### PR TITLE
Rename `is` to `isInstanceOf` in Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to semantic versioning.
 
 - Remove `flip`. [fp-ts/function::flip](https://gcanti.github.io/fp-ts/modules/function.ts.html#flip) is now curried.
 - Bump minimum supported fp-ts version to 2.13.1.
+- Rename `is` in `Function` to `isInstanceOf` for readability.
 
 ## 0.15.1 (2022-11-18)
 

--- a/docs/ramda-comparison.md
+++ b/docs/ramda-comparison.md
@@ -111,7 +111,7 @@ Note that some functions are not one-to-one replacements, but rather bequeath a 
 - [x] invert - [fp-ts-std/Record::invertAll](https://samhh.github.io/fp-ts-std/modules/Record.ts.html#invertall)
 - [x] invertObj - [fp-ts-std/Record::invertLast](https://samhh.github.io/fp-ts-std/modules/Record.ts.html#invertlast)
 - [x] invoker - [fp-ts-std/Function::invoke](https://samhh.github.io/fp-ts-std/modules/Function.ts.html#invoke)
-- [x] is - [io-ts](https://gcanti.github.io/io-ts/) / [fp-ts-std/Function::is](https://samhh.github.io/fp-ts-std/modules/Function.ts.html#is)
+- [x] is - [io-ts](https://gcanti.github.io/io-ts/) / [fp-ts-std/Function::isInstanceOf](https://samhh.github.io/fp-ts-std/modules/Function.ts.html#isInstanceOf)
 - [x] isEmpty - [fp-ts/Array::isEmpty](https://gcanti.github.io/fp-ts/modules/Array.ts.html#isempty)/[fp-ts/Record::isEmpty](https://gcanti.github.io/fp-ts/modules/Record.ts.html#isempty)/[fp-ts/string::isEmpty](https://gcanti.github.io/fp-ts/modules/string.ts.html#isempty)
 - ~~[ ] isNil~~ Prefer `Option` type. Failing that, create `Eq` instances for `null` and `undefined`.
 - [x] join - [fp-ts-std/Array::join](https://samhh.github.io/fp-ts-std/modules/Array.ts.html#join)

--- a/src/Date.ts
+++ b/src/Date.ts
@@ -15,7 +15,7 @@ import * as IO from "fp-ts/IO"
 type IO<A> = IO.IO<A>
 import { Option } from "fp-ts/Option"
 import * as O from "fp-ts/Option"
-import { construct, invokeOn, is } from "./Function"
+import { construct, invokeOn, isInstanceOf } from "./Function"
 import { pack, unpack } from "./Newtype"
 
 /**
@@ -152,7 +152,7 @@ export const toUTCString: (x: Date) => string = invokeOn<Date>()("toUTCString")(
  *
  * @since 0.1.0
  */
-export const isDate: Refinement<unknown, Date> = is(Date)
+export const isDate: Refinement<unknown, Date> = isInstanceOf(Date)
 
 /**
  * Check if a `Date` is actually valid. (We all love JavaScript, don't we?)

--- a/src/Function.ts
+++ b/src/Function.ts
@@ -767,16 +767,16 @@ export const converge =
  * absolutely must test a prototype.
  *
  * @example
- * import { is } from 'fp-ts-std/Function'
+ * import { isInstanceOf } from 'fp-ts-std/Function'
  *
- * const isString = is(String)
+ * const isStringInstance = isInstanceOf(String)
  *
- * assert.strictEqual(isString('ciao'), false)
- * assert.strictEqual(isString(new String('ciao')), true)
+ * assert.strictEqual(isStringInstance('ciao'), false)
+ * assert.strictEqual(isStringInstance(new String('ciao')), true)
  *
- * @since 0.12.0
+ * @since 0.16.0
  */
-export const is =
+export const isInstanceOf =
   <A>(x: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     new (...args: Array<any>): unknown

--- a/src/URL.ts
+++ b/src/URL.ts
@@ -10,7 +10,7 @@ import { Either } from "fp-ts/Either"
 import * as E from "fp-ts/Either"
 import { flow, identity, pipe } from "fp-ts/function"
 import { Refinement } from "fp-ts/Refinement"
-import { construct, is } from "./Function"
+import { construct, isInstanceOf } from "./Function"
 
 /**
  * Unsafely parse a `URL`, throwing on failure.
@@ -79,4 +79,4 @@ export const parseO: (href: string) => Option<URL> = flow(
  *
  * @since 0.1.0
  */
-export const isURL: Refinement<unknown, URL> = is(URL)
+export const isURL: Refinement<unknown, URL> = isInstanceOf(URL)

--- a/src/URLSearchParams.ts
+++ b/src/URLSearchParams.ts
@@ -10,7 +10,7 @@ import * as O from "fp-ts/Option"
 import * as R from "fp-ts/Record"
 import { flow, pipe } from "fp-ts/function"
 import { Refinement } from "fp-ts/Refinement"
-import { construct, invoke, is } from "./Function"
+import { construct, invoke, isInstanceOf } from "./Function"
 
 /**
  * An empty `URLSearchParams`.
@@ -101,7 +101,7 @@ export const clone = (x: URLSearchParams): URLSearchParams =>
  * @since 0.1.0
  */
 export const isURLSearchParams: Refinement<unknown, URLSearchParams> =
-  is(URLSearchParams)
+  isInstanceOf(URLSearchParams)
 
 /**
  * Attempt to get a URL parameter from a `URLSearchParams`.

--- a/test/Function.ts
+++ b/test/Function.ts
@@ -26,7 +26,7 @@ import {
   uncurry5,
   fork,
   converge,
-  is,
+  isInstanceOf,
   applyEvery,
   applySomes,
 } from "../src/Function"
@@ -641,15 +641,16 @@ describe("Function", () => {
     })
   })
 
-  describe("is", () => {
+  describe("isInstanceOf", () => {
     it("is equivalent to instanceof operator", () => {
       // eslint-disable-next-line functional/no-class
       class X {}
       const x = new X()
 
-      expect(is(X)(x)).toBe(true)
-      expect(is(Object)(x)).toBe(true)
-      expect(is(Function)(x)).toBe(false)
+      expect(isInstanceOf(X)(x)).toBe(true)
+      expect(isInstanceOf(Object)(x)).toBe(true)
+      expect(isInstanceOf(Function)(x)).toBe(false)
+      expect(isInstanceOf(String)("abcd")).toBe(false)
     })
   })
 


### PR DESCRIPTION
Assume this is intended to be a breaking change by targeting to upcoming version **0.16**, thus skipped deprecation story (e.g. having `is` around with `@deprecated` jsdoc label).

The `yarn docs` task got green on CI, but for some reason it kept failure when trigger manually in local environment, in which preventing from generate & commit docs related change. My hunch is due to exit code reading from example code execution (i.e. src/Debug.ts) by **docs-ts** in different tty from [docs-ts/src/Example.ts#L33-L37][1], but haven't gone further, any suggestion on how to proceed would be great.




----
resolves #154 



[1]: https://github.com/gcanti/docs-ts/blob/0efb7a6ed3f64f3a9a8e728fcb92eab18043011d/src/Example.ts#L33-L37