### PR TITLE
fix: add better struct pick type

### DIFF
--- a/src/ReadonlyStruct.ts
+++ b/src/ReadonlyStruct.ts
@@ -45,13 +45,13 @@ export const merge =
  */
 export const pick =
   <A, K extends keyof A>(ks: ReadonlyArray<K>) =>
-  (x: A): Pick<A, K> =>
+  (x: A): Pick<A, Extract<keyof A, K>> =>
     // I don't believe there's any reasonable way to model this sort of
     // transformation in the type system without an assertion - at least here
     // it's in a single reused place
     pipe(
       ks,
-      RA.reduce({} as Pick<A, K>, (ys, k) =>
+      RA.reduce({} as Pick<A, Extract<keyof A, K>>, (ys, k) =>
         merge(ys)(k in x ? { [k]: x[k] } : {}),
       ),
     )
@@ -83,7 +83,7 @@ export const pick =
  */
 export const pickFrom = <A>(): (<K extends keyof A>(
   ks: ReadonlyArray<K>,
-) => (x: A) => Pick<A, K>) => pick
+) => (x: A) => Pick<A, Extract<keyof A, K>>) => pick
 
 /**
  * Omit a set of keys from a `Record`. The value-level equivalent of the `Omit`

--- a/src/Struct.ts
+++ b/src/Struct.ts
@@ -44,13 +44,13 @@ export const merge =
  */
 export const pick =
   <A, K extends keyof A>(ks: Array<K>) =>
-  (x: A): Pick<A, K> =>
+  (x: A): Pick<A, Extract<keyof A, K>> =>
     // I don't believe there's any reasonable way to model this sort of
     // transformation in the type system without an assertion - at least here
     // it's in a single reused place.
     pipe(
       ks,
-      A.reduce({} as Pick<A, K>, (ys, k) =>
+      A.reduce({} as Pick<A, Extract<keyof A, K>>, (ys, k) =>
         merge(ys)(k in x ? { [k]: x[k] } : {}),
       ),
     )
@@ -70,7 +70,7 @@ export const pick =
  */
 export const pickFrom = <A>(): (<K extends keyof A>(
   ks: Array<K>,
-) => (x: A) => Pick<A, K>) => pick
+) => (x: A) => Pick<A, Extract<keyof A, K>>) => pick
 
 /**
  * Omit a set of keys from a `Record`. The value-level equivalent of the `Omit`


### PR DESCRIPTION
Add better `Pick` type to `Struct` and `ReadonlyStruct` modules.

Example:

```ts
import { pick } from 'fp-ts-std/Struct'

const AttributesKeys = ['key1' as const, 'key2' as const]
const getAttributes = <A extends Record<string, unknown>>(x: A) =>
    pipe(x, pick(AttributesKeys))
    
declare const y: { key1: string, foo: string }

const result = getAttributes(y) 
```

Currently:
```
typeof result = {
    key1: string
    key2: unknown
}
```

With this MR:

```
typeof result = {
    key1: string
}
```