### PR TITLE
changes DOM.addEventListener to returning a cleanup function

### DIFF
--- a/docs/modules/Alternative.ts.md
+++ b/docs/modules/Alternative.ts.md
@@ -52,16 +52,6 @@ export declare function altAllBy<F extends URIS>(
 export declare function altAllBy<F>(F: Alternative<F>): <B, A>(fs: Array<(x: A) => HKT<F, B>>) => (x: A) => HKT<F, B>
 ```
 
-```hs
-altAllBy :: f extends URIS4 => Alternative4 f -> Array (a -> (Kind4 f s r e b)) -> a -> Kind4 f s r e b
-altAllBy :: f extends URIS3 => ((Alternative3 f) -> Array (a -> (Kind3 f r e b)) -> a -> Kind3 f r e b)
-altAllBy :: f extends URIS3 => ((Alternative3C f e) -> Array (a -> (Kind3 f r e b)) -> a -> Kind3 f r e b)
-altAllBy :: f extends URIS2 => ((Alternative2 f) -> Array (a -> (Kind2 f e b)) -> a -> Kind2 f e b)
-altAllBy :: f extends URIS2 => ((Alternative2C f e) -> Array (a -> (Kind2 f e b)) -> a -> Kind2 f e b)
-altAllBy :: f extends URIS => ((Alternative1 f) -> Array (a -> (Kind f b)) -> a -> Kind f b)
-altAllBy :: ((Alternative f) -> Array (a -> (HKT f b)) -> a -> HKT f b)
-```
-
 **Example**
 
 ```ts
@@ -100,15 +90,6 @@ export declare function pureIf<F extends URIS2, E>(
   F: Alternative2C<F, E>
 ): (x: boolean) => <A>(y: Lazy<A>) => Kind2<F, E, A>
 export declare function pureIf<F extends URIS>(F: Alternative1<F>): (x: boolean) => <A>(y: Lazy<A>) => Kind<F, A>
-```
-
-```hs
-pureIf :: f extends URIS4 => Alternative4 f -> boolean -> Lazy a -> Kind4 f s r e a
-pureIf :: f extends URIS3 => ((Alternative3 f) -> boolean -> Lazy a -> Kind3 f r e a)
-pureIf :: f extends URIS3 => ((Alternative3C f e) -> boolean -> Lazy a -> Kind3 f r e a)
-pureIf :: f extends URIS2 => ((Alternative2 f) -> boolean -> Lazy a -> Kind2 f e a)
-pureIf :: f extends URIS2 => ((Alternative2C f e) -> boolean -> Lazy a -> Kind2 f e a)
-pureIf :: f extends URIS => ((Alternative1 f) -> boolean -> Lazy a -> Kind f a)
 ```
 
 **Example**

--- a/docs/modules/Applicative.ts.md
+++ b/docs/modules/Applicative.ts.md
@@ -47,15 +47,6 @@ export declare function unless<F extends URIS2, E>(
 export declare function unless<F extends URIS>(F: Applicative1<F>): (b: boolean) => (x: Kind<F, void>) => Kind<F, void>
 ```
 
-```hs
-unless :: f extends URIS4 => Applicative4 f -> boolean -> Kind4 f s r e void -> Kind4 f s r e void
-unless :: f extends URIS3 => ((Applicative3 f) -> boolean -> Kind3 f r e void -> Kind3 f r e void)
-unless :: f extends URIS3 => ((Applicative3C f e) -> boolean -> Kind3 f r e void -> Kind3 f r e void)
-unless :: f extends URIS2 => ((Applicative2 f) -> boolean -> Kind2 f e void -> Kind2 f e void)
-unless :: f extends URIS2 => ((Applicative2C f e) -> boolean -> Kind2 f e void -> Kind2 f e void)
-unless :: f extends URIS => ((Applicative1 f) -> boolean -> Kind f void -> Kind f void)
-```
-
 **Example**
 
 ```ts
@@ -100,15 +91,6 @@ export declare function when<F extends URIS2, E>(
   F: Applicative2C<F, E>
 ): (b: boolean) => (x: Kind2<F, E, void>) => Kind2<F, E, void>
 export declare function when<F extends URIS>(F: Applicative1<F>): (b: boolean) => (x: Kind<F, void>) => Kind<F, void>
-```
-
-```hs
-when :: f extends URIS4 => Applicative4 f -> boolean -> Kind4 f s r e void -> Kind4 f s r e void
-when :: f extends URIS3 => ((Applicative3 f) -> boolean -> Kind3 f r e void -> Kind3 f r e void)
-when :: f extends URIS3 => ((Applicative3C f e) -> boolean -> Kind3 f r e void -> Kind3 f r e void)
-when :: f extends URIS2 => ((Applicative2 f) -> boolean -> Kind2 f e void -> Kind2 f e void)
-when :: f extends URIS2 => ((Applicative2C f e) -> boolean -> Kind2 f e void -> Kind2 f e void)
-when :: f extends URIS => ((Applicative1 f) -> boolean -> Kind f void -> Kind f void)
 ```
 
 **Example**

--- a/docs/modules/Array.ts.md
+++ b/docs/modules/Array.ts.md
@@ -85,15 +85,6 @@ export declare function allM<M extends URIS2, E>(
 export declare function allM<M extends URIS>(M: Monad1<M>): (xs: Array<Kind<M, boolean>>) => Kind<M, boolean>
 ```
 
-```hs
-allM :: m extends URIS4 => Monad4 m -> Array (Kind4 m s r e boolean) -> Kind4 m s r e boolean
-allM :: m extends URIS3 => ((Monad3 m) -> Array (Kind3 m r e boolean) -> Kind3 m r e boolean)
-allM :: m extends URIS3 => ((Monad3C m e) -> Array (Kind3 m r e boolean) -> Kind3 m r e boolean)
-allM :: m extends URIS2 => ((Monad2 m) -> Array (Kind2 m e boolean) -> Kind2 m e boolean)
-allM :: m extends URIS2 => ((Monad2C m e) -> Array (Kind2 m e boolean) -> Kind2 m e boolean)
-allM :: m extends URIS => ((Monad1 m) -> Array (Kind m boolean) -> Kind m boolean)
-```
-
 **Example**
 
 ```ts
@@ -135,15 +126,6 @@ export declare function anyM<M extends URIS2, E>(
 export declare function anyM<M extends URIS>(M: Monad1<M>): (xs: Array<Kind<M, boolean>>) => Kind<M, boolean>
 ```
 
-```hs
-anyM :: m extends URIS4 => Monad4 m -> Array (Kind4 m s r e boolean) -> Kind4 m s r e boolean
-anyM :: m extends URIS3 => ((Monad3 m) -> Array (Kind3 m r e boolean) -> Kind3 m r e boolean)
-anyM :: m extends URIS3 => ((Monad3C m e) -> Array (Kind3 m r e boolean) -> Kind3 m r e boolean)
-anyM :: m extends URIS2 => ((Monad2 m) -> Array (Kind2 m e boolean) -> Kind2 m e boolean)
-anyM :: m extends URIS2 => ((Monad2C m e) -> Array (Kind2 m e boolean) -> Kind2 m e boolean)
-anyM :: m extends URIS => ((Monad1 m) -> Array (Kind m boolean) -> Kind m boolean)
-```
-
 **Example**
 
 ```ts
@@ -172,10 +154,6 @@ If `n` is greater than the length of the array, an empty array is returned.
 
 ```ts
 export declare const aperture: (n: number) => <A>(xs: A[]) => A[][]
-```
-
-```hs
-aperture :: number -> Array a -> Array (Array a)
 ```
 
 **Example**
@@ -210,10 +188,6 @@ possible ordered combination of the two input arrays.
 export declare const cartesian: <A>(xs: A[]) => <B>(ys: B[]) => [A, B][]
 ```
 
-```hs
-cartesian :: Array a -> Array b -> Array [a, b]
-```
-
 **Example**
 
 ```ts
@@ -239,10 +213,6 @@ Map each item of an array to a key, and count how many map to each key.
 
 ```ts
 export declare const countBy: <A>(f: (x: A) => string) => (xs: A[]) => Record<string, number>
-```
-
-```hs
-countBy :: (a -> string) -> Array a -> Record string number
 ```
 
 **Example**
@@ -281,10 +251,6 @@ If `n` is a float, it will be rounded down to the nearest integer.
 export declare const dropAt: (i: number) => (n: number) => <A>(xs: A[]) => Option<A[]>
 ```
 
-```hs
-dropAt :: number -> number -> Array a -> Option (Array a)
-```
-
 **Example**
 
 ```ts
@@ -308,10 +274,6 @@ Filter a list, removing any elements that repeat that directly precede them.
 export declare const dropRepeats: <A>(eq: Eq<A>) => Endomorphism<A[]>
 ```
 
-```hs
-dropRepeats :: Eq a -> Endomorphism (Array a)
-```
-
 **Example**
 
 ```ts
@@ -332,10 +294,6 @@ which all elements satisfy the specified predicate, creating a new array.
 
 ```ts
 export declare const dropRightWhile: <A>(f: Predicate<A>) => <B extends A>(xs: B[]) => B[]
-```
-
-```hs
-dropRightWhile :: b extends a => Predicate a -> Array b -> Array b
 ```
 
 **Example**
@@ -362,10 +320,6 @@ Like `fp-ts/Array::elem` but flipped, which the "V" suffix denotes.
 export declare const elemV: <A>(eq: Eq<A>) => (xs: A[]) => Predicate<A>
 ```
 
-```hs
-elemV :: Eq a -> Array a -> Predicate a
-```
-
 **Example**
 
 ```ts
@@ -388,10 +342,6 @@ Check if an array ends with the specified subarray.
 
 ```ts
 export declare const endsWith: <A>(eq: Eq<A>) => (end: A[]) => Predicate<A[]>
-```
-
-```hs
-endsWith :: Eq a -> Array a -> Predicate (Array a)
 ```
 
 **Example**
@@ -417,10 +367,6 @@ the remaining array. Returns `None` if the index is out of bounds.
 
 ```ts
 export declare const extractAt: (i: number) => <A>(xs: A[]) => Option<[A, A[]]>
-```
-
-```hs
-extractAt :: number -> Array a -> Option [a, (Array a)]
 ```
 
 **Example**
@@ -466,15 +412,6 @@ export declare function filterA<F>(
 ): <A>(p: (x: A) => HKT<F, boolean>) => (xs: Array<A>) => HKT<F, Array<A>>
 ```
 
-```hs
-filterA :: f extends URIS4 => Applicative4 f -> (a -> Kind4 f s r e boolean) -> Array a -> Kind4 f s r e (Array a)
-filterA :: f extends URIS3 => ((Applicative3 f) -> (a -> Kind3 f r e boolean) -> Array a -> Kind3 f r e (Array a))
-filterA :: f extends URIS2 => ((Applicative2 f) -> (a -> Kind2 f e boolean) -> Array a -> Kind2 f e (Array a))
-filterA :: f extends URIS2 => ((Applicative2C f e) -> (a -> Kind2 f e boolean) -> Array a -> Kind2 f e (Array a))
-filterA :: f extends URIS => ((Applicative1 f) -> (a -> Kind f boolean) -> Array a -> Kind f (Array a))
-filterA :: ((Applicative f) -> (a -> HKT f boolean) -> Array a -> HKT f (Array a))
-```
-
 **Example**
 
 ```ts
@@ -501,10 +438,6 @@ Convert an `Iterable` to an `Array`.
 export declare const fromIterable: <A>(xs: Iterable<A>) => A[]
 ```
 
-```hs
-fromIterable :: Iterable a -> Array a
-```
-
 **Example**
 
 ```ts
@@ -523,10 +456,6 @@ Copy a readonly array to a non-readonly array.
 
 ```ts
 export declare const fromReadonly: <A>(xs: readonly A[]) => A[]
-```
-
-```hs
-fromReadonly :: Array a -> Array a
 ```
 
 **Example**
@@ -549,10 +478,6 @@ and `getEq` should be preferred on ordered data.
 
 ```ts
 export declare const getDisorderedEq: <A>(ordA: Ord<A>) => Eq<A[]>
-```
-
-```hs
-getDisorderedEq :: Ord a -> Eq (Array a)
 ```
 
 **Example**
@@ -584,10 +509,6 @@ The array of elements to insert must be non-empty.
 export declare const insertMany: (i: number) => <A>(xs: NonEmptyArray<A>) => (ys: A[]) => Option<NonEmptyArray<A>>
 ```
 
-```hs
-insertMany :: number -> NonEmptyArray a -> Array a -> Option (NonEmptyArray a)
-```
-
 **Example**
 
 ```ts
@@ -611,10 +532,6 @@ separator.
 
 ```ts
 export declare const join: (x: string) => (ys: Array<string>) => string
-```
-
-```hs
-join :: string -> Array string -> string
 ```
 
 **Example**
@@ -641,10 +558,6 @@ Obtain the maximum value from a non-empty array.
 export declare const maximum: <A>(ord: Ord<A>) => (xs: NonEmptyArray<A>) => A
 ```
 
-```hs
-maximum :: Ord a -> NonEmptyArray a -> a
-```
-
 **Example**
 
 ```ts
@@ -664,10 +577,6 @@ Calculate the mean of an array of numbers.
 
 ```ts
 export declare const mean: (xs: NonEmptyArray<number>) => number
-```
-
-```hs
-mean :: NonEmptyArray number -> number
 ```
 
 **Example**
@@ -690,10 +599,6 @@ Calculate the median of an array of numbers.
 export declare const median: (xs: NonEmptyArray<number>) => number
 ```
 
-```hs
-median :: NonEmptyArray number -> number
-```
-
 **Example**
 
 ```ts
@@ -713,10 +618,6 @@ Obtain the minimum value from a non-empty array.
 
 ```ts
 export declare const minimum: <A>(ord: Ord<A>) => (xs: NonEmptyArray<A>) => A
-```
-
-```hs
-minimum :: Ord a -> NonEmptyArray a -> a
 ```
 
 **Example**
@@ -742,10 +643,6 @@ If both indices are the same, the array is returned unchanged.
 
 ```ts
 export declare const moveFrom: (from: number) => (to: number) => <A>(xs: A[]) => Option<A[]>
-```
-
-```hs
-moveFrom :: number -> number -> Array a -> Option (Array a)
 ```
 
 **Example**
@@ -777,10 +674,6 @@ If both indices are the same, the array is returned unchanged.
 export declare const moveTo: (x: number) => (y: number) => <A>(xs: A[]) => Option<A[]>
 ```
 
-```hs
-moveTo :: number -> number -> Array a -> Option (Array a)
-```
-
 **Example**
 
 ```ts
@@ -804,10 +697,6 @@ Check if a predicate does not hold for any array member.
 
 ```ts
 export declare const none: <A>(f: Predicate<A>) => Predicate<A[]>
-```
-
-```hs
-none :: Predicate a -> Predicate (Array a)
 ```
 
 **Example**
@@ -839,10 +728,6 @@ the remaining items, sans the match (if any), are returned as well.
 export declare const pluckFirst: <A>(p: Predicate<A>) => (xs: A[]) => [Option<A>, A[]]
 ```
 
-```hs
-pluckFirst :: Predicate a -> Array a -> [Option a, Array a]
-```
-
 **Example**
 
 ```ts
@@ -869,10 +754,6 @@ Multiplies together all the numbers in the input array.
 export declare const product: (xs: Array<number>) => number
 ```
 
-```hs
-product :: Array number -> number
-```
-
 **Example**
 
 ```ts
@@ -895,10 +776,6 @@ short-circuits and returns the current accumulator value.
 
 ```ts
 export declare const reduceRightWhile: <A>(p: Predicate<A>) => <B>(f: (x: A) => (y: B) => B) => (x: B) => (ys: A[]) => B
-```
-
-```hs
-reduceRightWhile :: Predicate a -> (a -> b -> b) -> b -> Array a -> b
 ```
 
 **Example**
@@ -928,10 +805,6 @@ short-circuits and returns the current accumulator value.
 export declare const reduceWhile: <A>(p: Predicate<A>) => <B>(f: (x: A) => (y: B) => B) => (x: B) => (ys: A[]) => B
 ```
 
-```hs
-reduceWhile :: Predicate a -> (a -> b -> b) -> b -> Array a -> b
-```
-
 **Example**
 
 ```ts
@@ -956,10 +829,6 @@ thought of as the inverse of ordinary array filtering.
 
 ```ts
 export declare const reject: <A>(f: Predicate<A>) => <B extends A>(xs: B[]) => B[]
-```
-
-```hs
-reject :: b extends a => Predicate a -> Array b -> Array b
 ```
 
 **Example**
@@ -988,10 +857,6 @@ This is merely a functional wrapper around `Array.prototype.slice`.
 export declare const slice: (start: number) => (end: number) => <A>(xs: A[]) => A[]
 ```
 
-```hs
-slice :: number -> number -> Array a -> Array a
-```
-
 **Example**
 
 ```ts
@@ -1015,10 +880,6 @@ Check if an array starts with the specified subarray.
 
 ```ts
 export declare const startsWith: <A>(eq: Eq<A>) => (start: A[]) => Predicate<A[]>
-```
-
-```hs
-startsWith :: Eq a -> Array a -> Predicate (Array a)
 ```
 
 **Example**
@@ -1045,10 +906,6 @@ Adds together all the numbers in the input array.
 export declare const sum: (xs: Array<number>) => number
 ```
 
-```hs
-sum :: Array number -> number
-```
-
 **Example**
 
 ```ts
@@ -1072,10 +929,6 @@ duplicate values present only in one input array are maintained.
 export declare const symmetricDifference: <A>(eq: Eq<A>) => (xs: A[]) => Endomorphism<A[]>
 ```
 
-```hs
-symmetricDifference :: Eq a -> Array a -> Endomorphism (Array a)
-```
-
 **Example**
 
 ```ts
@@ -1097,10 +950,6 @@ which all elements satisfy the specified predicate, creating a new array.
 
 ```ts
 export declare const takeRightWhile: <A>(f: Predicate<A>) => <B extends A>(xs: B[]) => B[]
-```
-
-```hs
-takeRightWhile :: b extends a => Predicate a -> Array b -> Array b
 ```
 
 **Example**
@@ -1127,10 +976,6 @@ Copy a non-readonly array to a readonly array.
 export declare const toReadonly: <A>(xs: A[]) => readonly A[]
 ```
 
-```hs
-toReadonly :: Array a -> Array a
-```
-
 **Example**
 
 ```ts
@@ -1150,10 +995,6 @@ than the following rows, their elements are skipped.
 
 ```ts
 export declare const transpose: <A>(xs: A[][]) => A[][]
-```
-
-```hs
-transpose :: Array (Array a) -> Array (Array a)
 ```
 
 **Example**
@@ -1200,10 +1041,6 @@ the array is checked is unspecified.
 
 ```ts
 export declare const upsert: <A>(eqA: Eq<A>) => (x: A) => (ys: A[]) => NonEmptyArray<A>
-```
-
-```hs
-upsert :: Eq a -> a -> Array a -> NonEmptyArray a
 ```
 
 **Example**
@@ -1258,10 +1095,6 @@ Returns a new array without the values present in the first input array.
 export declare const without: <A>(eq: Eq<A>) => (xs: A[]) => Endomorphism<A[]>
 ```
 
-```hs
-without :: Eq a -> Array a -> Endomorphism (Array a)
-```
-
 **Example**
 
 ```ts
@@ -1288,10 +1121,6 @@ input sizes via the `These` type.
 
 ```ts
 export declare const zipAll: <A>(xs: A[]) => <B>(ys: B[]) => These<B, A>[]
-```
-
-```hs
-zipAll :: Array a -> Array b -> Array (These b a)
 ```
 
 **Example**

--- a/docs/modules/Bifunctor.ts.md
+++ b/docs/modules/Bifunctor.ts.md
@@ -48,15 +48,6 @@ export declare function mapBoth<F extends URIS2>(
 ): <A, B>(f: (x: A) => B) => (x: Kind2<F, A, A>) => Kind2<F, B, B>
 ```
 
-```hs
-mapBoth :: f extends URIS4 => Bifunctor4 f -> (a -> b) -> Kind4 f s r a a -> Kind4 f s r b b
-mapBoth :: f extends URIS3 => ((Bifunctor3 f) -> (a -> b) -> Kind3 f r a a -> Kind3 f r b b)
-mapBoth :: f extends URIS3 => ((Bifunctor3C f e) -> (e -> b) -> Kind3 f r e e -> Kind3 f r b b)
-mapBoth :: f extends URIS2 => ((Bifunctor2 f) -> (a -> b) -> Kind2 f a a -> Kind2 f b b)
-mapBoth :: f extends URIS2 => ((Bifunctor2C f e) -> (e -> b) -> Kind2 f e e -> Kind2 f b b)
-mapBoth :: f extends URIS2 => ((Bifunctor f) -> (a -> b) -> Kind2 f a a -> Kind2 f b b)
-```
-
 **Example**
 
 ```ts

--- a/docs/modules/Boolean.ts.md
+++ b/docs/modules/Boolean.ts.md
@@ -36,10 +36,6 @@ logical conjunction.
 export declare const and: (x: boolean) => Endomorphism<boolean>
 ```
 
-```hs
-and :: boolean -> Endomorphism boolean
-```
-
 **Example**
 
 ```ts
@@ -59,10 +55,6 @@ Invert a boolean.
 
 ```ts
 export declare const invert: Endomorphism<boolean>
-```
-
-```hs
-invert :: Endomorphism boolean
 ```
 
 **Example**
@@ -87,10 +79,6 @@ to logical disjunction.
 export declare const or: (x: boolean) => Endomorphism<boolean>
 ```
 
-```hs
-or :: boolean -> Endomorphism boolean
-```
-
 **Example**
 
 ```ts
@@ -111,10 +99,6 @@ Returns `true` if one argument is `true` and the other is `false`, else
 
 ```ts
 export declare const xor: (x: boolean) => Endomorphism<boolean>
-```
-
-```hs
-xor :: boolean -> Endomorphism boolean
 ```
 
 **Example**

--- a/docs/modules/DOM.ts.md
+++ b/docs/modules/DOM.ts.md
@@ -36,15 +36,14 @@ Added in v0.12.0
 ## addEventListener
 
 Adds an event listener to a node.
+Returns a cleanup function for removing the event listener.
 
 **Signature**
 
 ```ts
-export declare const addEventListener: (type: string) => (f: (evt: Event) => IO<void>) => (x: Node) => IO<void>
-```
-
-```hs
-addEventListener :: string -> (Event -> IO void) -> Node -> IO void
+export declare const addEventListener: (
+  type: EventTarget
+) => (listener: EventListener) => (el: Node | Window) => () => IO<void>
 ```
 
 **Example**
@@ -65,10 +64,14 @@ assert.strictEqual(clicks, 0)
 el.click()
 assert.strictEqual(clicks, 0)
 
-listen()
+const cleanupClick = listen()
 el.click()
 assert.strictEqual(clicks, 1)
 
+el.click()
+assert.strictEqual(clicks, 2)
+
+cleanupClick()
 el.click()
 assert.strictEqual(clicks, 2)
 ```
@@ -83,10 +86,6 @@ Appends a node as a child of another.
 
 ```ts
 export declare const appendChild: (child: Node) => (parent: Node) => IO<void>
-```
-
-```hs
-appendChild :: Node -> Node -> IO void
 ```
 
 **Example**
@@ -123,10 +122,6 @@ Returns all child nodes, if any, of a node.
 export declare const childNodes: (x: Node) => IO<Option<NonEmptyArray<ChildNode>>>
 ```
 
-```hs
-childNodes :: Node -> IO (Option (NonEmptyArray ChildNode))
-```
-
 **Example**
 
 ```ts
@@ -156,10 +151,6 @@ Removes all the child nodes, if any, of a given node.
 
 ```ts
 export declare const emptyChildren: (x: Node) => IO<void>
-```
-
-```hs
-emptyChildren :: Node -> IO void
 ```
 
 **Example**
@@ -196,10 +187,6 @@ Convert a `NodeList` into an `Array`.
 export declare const fromNodeList: <A extends Node>(xs: NodeListOf<A>) => A[]
 ```
 
-```hs
-fromNodeList :: a extends Node => NodeListOf a -> Array a
-```
-
 **Example**
 
 ```ts
@@ -225,10 +212,6 @@ Gets the text content, if any, of a node.
 
 ```ts
 export declare const getTextContent: (x: Node) => IO<Option<string>>
-```
-
-```hs
-getTextContent :: Node -> IO (Option string)
 ```
 
 **Example**
@@ -260,10 +243,6 @@ selector.
 
 ```ts
 export declare const querySelector: (q: string) => (x: ParentNode) => IO<Option<Element>>
-```
-
-```hs
-querySelector :: string -> ParentNode -> IO (Option Element)
 ```
 
 **Example**
@@ -298,10 +277,6 @@ selector.
 export declare const querySelectorAll: (q: string) => (x: ParentNode) => IO<Option<NonEmptyArray<Element>>>
 ```
 
-```hs
-querySelectorAll :: string -> ParentNode -> IO (Option (NonEmptyArray Element))
-```
-
 **Example**
 
 ```ts
@@ -330,10 +305,6 @@ Removes a child node from the tree.
 
 ```ts
 export declare const remove: (x: ChildNode) => IO<void>
-```
-
-```hs
-remove :: ChildNode -> IO void
 ```
 
 **Example**
@@ -368,10 +339,6 @@ Sets the text content of a node.
 
 ```ts
 export declare const setTextContent: (x: string) => (y: Node) => IO<void>
-```
-
-```hs
-setTextContent :: string -> Node -> IO void
 ```
 
 **Example**

--- a/docs/modules/Date.ts.md
+++ b/docs/modules/Date.ts.md
@@ -45,10 +45,6 @@ Newtype representing milliseconds.
 export type Milliseconds = Newtype<MillisecondsSymbol, number>
 ```
 
-```hs
-type Milliseconds = Newtype MillisecondsSymbol number
-```
-
 Added in v0.7.0
 
 ## fieldMilliseconds
@@ -59,10 +55,6 @@ Added in v0.7.0
 
 ```ts
 export declare const fieldMilliseconds: Field<Milliseconds>
-```
-
-```hs
-fieldMilliseconds :: Field Milliseconds
 ```
 
 Added in v0.7.0
@@ -77,10 +69,6 @@ Get a `Date` from `Milliseconds`.
 export declare const fromMilliseconds: (x: Milliseconds) => Date
 ```
 
-```hs
-fromMilliseconds :: Milliseconds -> Date
-```
-
 Added in v0.7.0
 
 ## getTime
@@ -91,10 +79,6 @@ Get the time in milliseconds from a `Date`.
 
 ```ts
 export declare const getTime: (x: Date) => Milliseconds
-```
-
-```hs
-getTime :: Date -> Milliseconds
 ```
 
 **Example**
@@ -119,10 +103,6 @@ Check if a foreign value is a `Date`.
 export declare const isDate: Refinement<unknown, Date>
 ```
 
-```hs
-isDate :: Refinement unknown Date
-```
-
 **Example**
 
 ```ts
@@ -142,10 +122,6 @@ Check if a `Date` is actually valid. (We all love JavaScript, don't we?)
 
 ```ts
 export declare const isValid: Predicate<Date>
-```
-
-```hs
-isValid :: Predicate Date
 ```
 
 **Example**
@@ -173,10 +149,6 @@ newtype pertaining to its isomorphic nature.
 export declare const isoMilliseconds: Iso<Milliseconds, number>
 ```
 
-```hs
-isoMilliseconds :: Iso Milliseconds number
-```
-
 Added in v0.7.0
 
 ## mkMilliseconds
@@ -189,10 +161,6 @@ Lift a number to the `Milliseconds` newtype.
 export declare const mkMilliseconds: (n: number) => Milliseconds
 ```
 
-```hs
-mkMilliseconds :: number -> Milliseconds
-```
-
 Added in v0.7.0
 
 ## now
@@ -203,10 +171,6 @@ Get the time since the Unix Epoch in `Milliseconds` from a `Date`.
 
 ```ts
 export declare const now: IO<Milliseconds>
-```
-
-```hs
-now :: IO Milliseconds
 ```
 
 Added in v0.7.0
@@ -222,10 +186,6 @@ instances of the type.
 export declare const ordMilliseconds: Ord<Milliseconds>
 ```
 
-```hs
-ordMilliseconds :: Ord Milliseconds
-```
-
 Added in v0.7.0
 
 ## parseDate
@@ -236,10 +196,6 @@ Safely parse a date.
 
 ```ts
 export declare const parseDate: (ts: string | number) => Option<Date>
-```
-
-```hs
-parseDate :: string | number -> Option Date
 ```
 
 **Example**
@@ -267,10 +223,6 @@ Returns a date as a string value in ISO format.
 export declare const toISOString: (x: Date) => string
 ```
 
-```hs
-toISOString :: Date -> string
-```
-
 **Example**
 
 ```ts
@@ -291,10 +243,6 @@ Returns a date converted to a string using Universal Coordinated Time (UTC).
 
 ```ts
 export declare const toUTCString: (x: Date) => string
-```
-
-```hs
-toUTCString :: Date -> string
 ```
 
 **Example**
@@ -319,10 +267,6 @@ Unwrap a `Milliseconds` newtype back to its underlying number representation.
 export declare const unMilliseconds: (ms: Milliseconds) => number
 ```
 
-```hs
-unMilliseconds :: Milliseconds -> number
-```
-
 Added in v0.7.0
 
 ## unsafeParseDate
@@ -334,10 +278,6 @@ invalid `Date` being returned.
 
 ```ts
 export declare const unsafeParseDate: (x: string | number) => Date
-```
-
-```hs
-unsafeParseDate :: string | number -> Date
 ```
 
 **Example**

--- a/docs/modules/Debug.ts.md
+++ b/docs/modules/Debug.ts.md
@@ -38,10 +38,6 @@ it has the side effect of outputting the trace message.
 export declare const trace: (msg: string) => <A>(x: A) => A
 ```
 
-```hs
-trace :: string -> a -> a
-```
-
 **Example**
 
 ```ts
@@ -68,10 +64,6 @@ Like `trace`, but logs the generic value too.
 
 ```ts
 export declare const traceWithValue: (msg: string) => <A>(x: A) => A
-```
-
-```hs
-traceWithValue :: string -> a -> a
 ```
 
 **Example**

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -33,10 +33,6 @@ Apply a function to both elements of an `Either`.
 export declare const mapBoth: <A, B>(f: (x: A) => B) => (xs: Either<A, A>) => Either<B, B>
 ```
 
-```hs
-mapBoth :: (a -> b) -> Either a a -> Either b b
-```
-
 **Example**
 
 ```ts
@@ -63,10 +59,6 @@ if `Left`.
 export declare const unsafeUnwrap: <A>(x: Either<unknown, A>) => A
 ```
 
-```hs
-unsafeUnwrap :: Either unknown a -> a
-```
-
 **Example**
 
 ```ts
@@ -87,10 +79,6 @@ if `Right`.
 
 ```ts
 export declare const unsafeUnwrapLeft: <E>(x: Either<E, unknown>) => E
-```
-
-```hs
-unsafeUnwrapLeft :: Either e unknown -> e
 ```
 
 **Example**

--- a/docs/modules/Env.ts.md
+++ b/docs/modules/Env.ts.md
@@ -33,10 +33,6 @@ Attempt to get an environment parameter.
 export declare const getParam: (k: string) => IO<Option<string>>
 ```
 
-```hs
-getParam :: string -> IO (Option string)
-```
-
 **Example**
 
 ```ts
@@ -58,10 +54,6 @@ Attempt to get an environment parameter, filtering out empty strings.
 
 ```ts
 export declare const getParamNonEmpty: (k: string) => IO<Option<string>>
-```
-
-```hs
-getParamNonEmpty :: string -> IO (Option string)
 ```
 
 **Example**

--- a/docs/modules/Function.ts.md
+++ b/docs/modules/Function.ts.md
@@ -73,10 +73,6 @@ higher-kinded functions that require it.
 export declare const Applicative: Applicative2<'Function'>
 ```
 
-```hs
-Applicative :: Applicative2 "Function"
-```
-
 Added in v0.15.0
 
 ## Functor
@@ -88,10 +84,6 @@ higher-kinded functions that require it.
 
 ```ts
 export declare const Functor: Functor2<'Function'>
-```
-
-```hs
-Functor :: Functor2 "Function"
 ```
 
 Added in v0.15.0
@@ -107,10 +99,6 @@ functions that require it.
 export declare const Monad: Monad2<'Function'>
 ```
 
-```hs
-Monad :: Monad2 "Function"
-```
-
 Added in v0.15.0
 
 ## URI
@@ -123,10 +111,6 @@ Typeclass machinery.
 export declare const URI: 'Function'
 ```
 
-```hs
-URI :: "Function"
-```
-
 Added in v0.15.0
 
 ## URI (type alias)
@@ -137,10 +121,6 @@ Typeclass machinery.
 
 ```ts
 export type URI = typeof URI
-```
-
-```hs
-type URI = typeof URI
 ```
 
 Added in v0.15.0
@@ -156,10 +136,6 @@ of the former to the latter.
 export declare const ap: <A, B>(f: (x: A) => B) => <C>(g: (x: A) => (y: B) => C) => (x: A) => C
 ```
 
-```hs
-ap :: (a -> b) -> (a -> b -> c) -> a -> c
-```
-
 Added in v0.15.0
 
 ## applyEvery
@@ -170,10 +146,6 @@ Apply an array of endomorphisms from left-to-right.
 
 ```ts
 export declare const applyEvery: <A>(fs: Endomorphism<A>[]) => Endomorphism<A>
-```
-
-```hs
-applyEvery :: Array (Endomorphism a) -> Endomorphism a
 ```
 
 **Example**
@@ -233,10 +205,6 @@ the former to the latter. As it applies to functions this is essentially
 export declare const chain: <A, B, C>(f: (x: B) => (y: A) => C) => (g: (x: A) => B) => (x: A) => C
 ```
 
-```hs
-chain :: (b -> a -> c) -> (a -> b) -> a -> c
-```
-
 Added in v0.15.0
 
 ## construct
@@ -247,10 +215,6 @@ Wraps a constructor function for functional invocation.
 
 ```ts
 export declare const construct: <A extends unknown[], B>(x: new (...xs: A) => B) => (xs: A) => B
-```
-
-```hs
-construct :: a extends (Array unknown) => (...a -> b) -> a -> b
 ```
 
 **Example**
@@ -305,10 +269,6 @@ Curry a function with binary input.
 export declare const curry2: <A, B, C>(f: (a: A, b: B) => C) => (a: A) => (b: B) => C
 ```
 
-```hs
-curry2 :: ((a, b) -> c) -> a -> b -> c
-```
-
 **Example**
 
 ```ts
@@ -329,10 +289,6 @@ Curry a function with binary tuple input.
 
 ```ts
 export declare const curry2T: <A, B, C>(f: (xs: [A, B]) => C) => (a: A) => (b: B) => C
-```
-
-```hs
-curry2T :: ([a, b] -> c) -> a -> b -> c
 ```
 
 **Example**
@@ -357,10 +313,6 @@ Curry a function with ternary input.
 export declare const curry3: <A, B, C, D>(f: (a: A, b: B, c: C) => D) => (a: A) => (b: B) => (c: C) => D
 ```
 
-```hs
-curry3 :: ((a, b, c) -> d) -> a -> b -> c -> d
-```
-
 **Example**
 
 ```ts
@@ -381,10 +333,6 @@ Curry a function with ternary tuple input.
 
 ```ts
 export declare const curry3T: <A, B, C, D>(f: (xs: [A, B, C]) => D) => (a: A) => (b: B) => (c: C) => D
-```
-
-```hs
-curry3T :: ([a, b, c] -> d) -> a -> b -> c -> d
 ```
 
 **Example**
@@ -411,10 +359,6 @@ export declare const curry4: <A, B, C, D, E>(
 ) => (a: A) => (b: B) => (c: C) => (d: D) => E
 ```
 
-```hs
-curry4 :: ((a, b, c, d) -> e) -> a -> b -> c -> d -> e
-```
-
 **Example**
 
 ```ts
@@ -435,10 +379,6 @@ Curry a function with quaternary tuple input.
 
 ```ts
 export declare const curry4T: <A, B, C, D, E>(f: (xs: [A, B, C, D]) => E) => (a: A) => (b: B) => (c: C) => (d: D) => E
-```
-
-```hs
-curry4T :: ([a, b, c, d] -> e) -> a -> b -> c -> d -> e
 ```
 
 **Example**
@@ -465,10 +405,6 @@ export declare const curry5: <A, B, C, D, E, F>(
 ) => (a: A) => (b: B) => (c: C) => (d: D) => (e: E) => F
 ```
 
-```hs
-curry5 :: ((a, b, c, d, e) -> f) -> a -> b -> c -> d -> e -> f
-```
-
 **Example**
 
 ```ts
@@ -493,10 +429,6 @@ export declare const curry5T: <A, B, C, D, E, F>(
 ) => (a: A) => (b: B) => (c: C) => (d: D) => (e: E) => F
 ```
 
-```hs
-curry5T :: ([a, b, c, d, e] -> f) -> a -> b -> c -> d -> e -> f
-```
-
 **Example**
 
 ```ts
@@ -517,10 +449,6 @@ Flip the function/argument order of a curried function.
 
 ```ts
 export declare const flip: <A, B, C>(f: (x: A) => (y: B) => C) => (x: B) => (y: A) => C
-```
-
-```hs
-flip :: (a -> b -> c) -> b -> a -> c
 ```
 
 **Example**
@@ -612,10 +540,6 @@ export declare const guard: <A, B>(
 ) => (fallback: (x: A) => B) => (input: A) => B
 ```
 
-```hs
-guard :: Array [(Predicate a), a -> b] -> (a -> b) -> a -> b
-```
-
 **Example**
 
 ```ts
@@ -645,10 +569,6 @@ succeeds, else the second morphism.
 
 ```ts
 export declare const ifElse: <A, B>(onTrue: (x: A) => B) => (onFalse: (x: A) => B) => (f: Predicate<A>) => (x: A) => B
-```
-
-```hs
-ifElse :: (a -> b) -> (a -> b) -> Predicate a -> a -> b
 ```
 
 **Example**
@@ -705,10 +625,6 @@ Added in v0.12.0
 export declare const invokeNullary: <A extends string>(x: A) => <B>(y: Record<A, () => B>) => B
 ```
 
-```hs
-invokeNullary :: a extends string => a -> Record a (() -> b) -> b
-```
-
 **Example**
 
 ```ts
@@ -762,10 +678,6 @@ absolutely must test a prototype.
 export declare const is: <A>(x: new (...args: Array<any>) => unknown) => Refinement<unknown, A>
 ```
 
-```hs
-is :: (...Array any -> unknown) -> Refinement unknown a
-```
-
 **Example**
 
 ```ts
@@ -789,10 +701,6 @@ Map a unary function's output. Equivalent to function composition.
 export declare const map: <B, C>(f: (x: B) => C) => <A>(g: (x: A) => B) => (x: A) => C
 ```
 
-```hs
-map :: (b -> c) -> (a -> b) -> a -> c
-```
-
 Added in v0.15.0
 
 ## memoize
@@ -811,10 +719,6 @@ cache entries can be cleared from memory.
 
 ```ts
 export declare const memoize: <A>(eq: Eq<A>) => <B>(f: (x: A) => B) => (x: A) => B
-```
-
-```hs
-memoize :: Eq a -> (a -> b) -> a -> b
 ```
 
 **Example**
@@ -849,10 +753,6 @@ Lift a value to a function from any other value. Equivalent to `constant`.
 export declare const of: <A>(x: A) => <B>(y: B) => A
 ```
 
-```hs
-of :: a -> b -> a
-```
-
 Added in v0.15.0
 
 ## unary
@@ -867,10 +767,6 @@ instead of more appropriately an array.
 
 ```ts
 export declare const unary: <A extends unknown[], B>(f: (...xs: A) => B) => (xs: A) => B
-```
-
-```hs
-unary :: a extends (Array unknown) => (...a -> b) -> a -> b
 ```
 
 **Example**
@@ -893,10 +789,6 @@ Uncurry a binary function.
 
 ```ts
 export declare const uncurry2: <A, B, C>(f: (a: A) => (b: B) => C) => ([a, b]: [A, B]) => C
-```
-
-```hs
-uncurry2 :: (a -> b -> c) -> [a, b] -> c
 ```
 
 **Example**
@@ -922,10 +814,6 @@ Uncurry a ternary function.
 
 ```ts
 export declare const uncurry3: <A, B, C, D>(f: (a: A) => (b: B) => (c: C) => D) => ([a, b, c]: [A, B, C]) => D
-```
-
-```hs
-uncurry3 :: (a -> b -> c -> d) -> [a, b, c] -> d
 ```
 
 **Example**
@@ -954,10 +842,6 @@ Uncurry a quaternary function.
 export declare const uncurry4: <A, B, C, D, E>(
   f: (a: A) => (b: B) => (c: C) => (d: D) => E
 ) => ([a, b, c, d]: [A, B, C, D]) => E
-```
-
-```hs
-uncurry4 :: (a -> b -> c -> d -> e) -> [a, b, c, d] -> e
 ```
 
 **Example**
@@ -989,10 +873,6 @@ export declare const uncurry5: <A, B, C, D, E, F>(
 ) => ([a, b, c, d, e]: [A, B, C, D, E]) => F
 ```
 
-```hs
-uncurry5 :: (a -> b -> c -> d -> e -> f) -> [a, b, c, d, e] -> f
-```
-
 **Example**
 
 ```ts
@@ -1019,10 +899,6 @@ Runs the provided morphism on the input value if the predicate fails.
 
 ```ts
 export declare const unless: <A>(f: Predicate<A>) => (onFalse: Endomorphism<A>) => Endomorphism<A>
-```
-
-```hs
-unless :: Predicate a -> Endomorphism a -> Endomorphism a
 ```
 
 **Example**
@@ -1052,10 +928,6 @@ holds.
 export declare const until: <A>(f: Predicate<A>) => (g: Endomorphism<A>) => Endomorphism<A>
 ```
 
-```hs
-until :: Predicate a -> Endomorphism a -> Endomorphism a
-```
-
 **Example**
 
 ```ts
@@ -1079,10 +951,6 @@ Runs the provided morphism on the input value if the predicate holds.
 
 ```ts
 export declare const when: <A>(f: Predicate<A>) => (onTrue: Endomorphism<A>) => Endomorphism<A>
-```
-
-```hs
-when :: Predicate a -> Endomorphism a -> Endomorphism a
 ```
 
 **Example**
@@ -1113,10 +981,6 @@ each iteration of the callback.
 export declare const withIndex: <A, B, C>(
   f: (g: (x: A) => B) => (ys: A[]) => C[]
 ) => (g: (i: number) => (x: A) => B) => (ys: A[]) => C[]
-```
-
-```hs
-withIndex :: ((a -> b) -> Array a -> Array c) -> (number -> a -> b) -> Array a -> Array c
 ```
 
 **Example**

--- a/docs/modules/IO.ts.md
+++ b/docs/modules/IO.ts.md
@@ -40,10 +40,6 @@ function application and composition pipelines.
 export declare const execute: <A>(x: IO<A>) => A
 ```
 
-```hs
-execute :: IO a -> a
-```
-
 **Example**
 
 ```ts
@@ -63,10 +59,6 @@ Memoize an `IO`, reusing the result of its first execution.
 
 ```ts
 export declare const memoize: <A>(f: IO<A>) => IO<A>
-```
-
-```hs
-memoize :: IO a -> IO a
 ```
 
 **Example**
@@ -91,10 +83,6 @@ value of its first invocation.
 
 ```ts
 export declare const once: <A, B>(f: (x: A) => B) => (x: A) => IO<B>
-```
-
-```hs
-once :: (a -> b) -> a -> IO b
 ```
 
 **Example**
@@ -122,10 +110,6 @@ Sequence an array of effects, ignoring the results.
 export declare const sequenceArray_: <A>(xs: readonly IO<A>[]) => IO<void>
 ```
 
-```hs
-sequenceArray_ :: Array (IO a) -> IO void
-```
-
 Added in v0.15.0
 
 ## tap
@@ -137,10 +121,6 @@ value.
 
 ```ts
 export declare const tap: <A>(f: (x: A) => IO<void>) => (x: A) => IO<A>
-```
-
-```hs
-tap :: (a -> IO void) -> a -> IO a
 ```
 
 **Example**
@@ -179,10 +159,6 @@ Map to and sequence an array of effects, ignoring the results.
 export declare const traverseArray_: <A, B>(f: (x: A) => IO<B>) => (xs: readonly A[]) => IO<void>
 ```
 
-```hs
-traverseArray_ :: (a -> IO b) -> Array a -> IO void
-```
-
 Added in v0.15.0
 
 ## unless
@@ -193,10 +169,6 @@ The reverse of `when`.
 
 ```ts
 export declare const unless: (x: boolean) => Endomorphism<IO<void>>
-```
-
-```hs
-unless :: boolean -> Endomorphism (IO void)
 ```
 
 **Example**
@@ -226,10 +198,6 @@ Conditional execution of an `IO`. Helpful for things like logging.
 
 ```ts
 export declare const when: (x: boolean) => Endomorphism<IO<void>>
-```
-
-```hs
-when :: boolean -> Endomorphism (IO void)
 ```
 
 **Example**
@@ -265,10 +233,6 @@ Invocations start at the number one.
 
 ```ts
 export declare const whenInvocationCount: (p: Predicate<number>) => Endomorphism<IO<void>>
-```
-
-```hs
-whenInvocationCount :: Predicate number -> Endomorphism (IO void)
 ```
 
 **Example**

--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -35,10 +35,6 @@ Apply a function to both elements of an `IOEither`.
 export declare const mapBoth: <A, B>(f: (x: A) => B) => (xs: IOEither<A, A>) => IOEither<B, B>
 ```
 
-```hs
-mapBoth :: (a -> b) -> IOEither a a -> IOEither b b
-```
-
 **Example**
 
 ```ts
@@ -65,10 +61,6 @@ Sequence an array of fallible effects, ignoring the results.
 export declare const sequenceArray_: <E, A>(xs: readonly IOEither<E, A>[]) => IOEither<E, void>
 ```
 
-```hs
-sequenceArray_ :: Array (IOEither e a) -> IOEither e void
-```
-
 Added in v0.15.0
 
 ## traverseArray\_
@@ -79,10 +71,6 @@ Map to and sequence an array of fallible effects, ignoring the results.
 
 ```ts
 export declare const traverseArray_: <E, A, B>(f: (x: A) => IOEither<E, B>) => (xs: readonly A[]) => IOEither<E, void>
-```
-
-```hs
-traverseArray_ :: (a -> IOEither e b) -> Array a -> IOEither e void
 ```
 
 Added in v0.15.0
@@ -96,10 +84,6 @@ Unwrap the value from within an `IOEither`, throwing with the inner value of
 
 ```ts
 export declare const unsafeUnwrap: <A>(x: IOEither<unknown, A>) => A
-```
-
-```hs
-unsafeUnwrap :: IOEither unknown a -> a
 ```
 
 **Example**
@@ -122,10 +106,6 @@ Unwrap the value from within an `IOEither`, throwing the inner value of
 
 ```ts
 export declare const unsafeUnwrapLeft: <E>(x: IOEither<E, unknown>) => E
-```
-
-```hs
-unsafeUnwrapLeft :: IOEither e unknown -> e
 ```
 
 **Example**

--- a/docs/modules/Isomorphism.ts.md
+++ b/docs/modules/Isomorphism.ts.md
@@ -46,10 +46,6 @@ export type Isomorphism<A, B> = {
 }
 ```
 
-```hs
-type Isomorphism a b = { to: a -> b, from: b -> a }
-```
-
 Added in v0.13.0
 
 ## compose
@@ -61,10 +57,6 @@ type signature a window into category theory!
 
 ```ts
 export declare const compose: <A, B>(F: Isomorphism<A, B>) => <C>(G: Isomorphism<B, C>) => Isomorphism<A, C>
-```
-
-```hs
-compose :: Isomorphism a b -> Isomorphism b c -> Isomorphism a c
 ```
 
 **Example**
@@ -109,10 +101,6 @@ Derive a `Monoid` for `B` given a `Monoid` for `A` and an
 export declare const deriveMonoid: <A, B>(I: Isomorphism<A, B>) => (M: Monoid<A>) => Monoid<B>
 ```
 
-```hs
-deriveMonoid :: Isomorphism a b -> Monoid a -> Monoid b
-```
-
 **Example**
 
 ```ts
@@ -147,10 +135,6 @@ Derive a `Semigroup` for `B` given a `Semigroup` for `A` and an
 export declare const deriveSemigroup: <A, B>(I: Isomorphism<A, B>) => (S: Semigroup<A>) => Semigroup<B>
 ```
 
-```hs
-deriveSemigroup :: Isomorphism a b -> Semigroup a -> Semigroup b
-```
-
 **Example**
 
 ```ts
@@ -183,10 +167,6 @@ Convert a monocle-ts `Iso` to an `Isomorphism`.
 export declare const fromIso: <A, B>(I: Iso<A, B>) => Isomorphism<A, B>
 ```
 
-```hs
-fromIso :: Iso a b -> Isomorphism a b
-```
-
 Added in v0.13.0
 
 ## reverse
@@ -199,10 +179,6 @@ Reverse the order of the types in an `Isomorphism`.
 export declare const reverse: <A, B>(I: Isomorphism<A, B>) => Isomorphism<B, A>
 ```
 
-```hs
-reverse :: Isomorphism a b -> Isomorphism b a
-```
-
 Added in v0.13.0
 
 ## toIso
@@ -213,10 +189,6 @@ Convert an `Isomorphism` to a monocle-ts `Iso`.
 
 ```ts
 export declare const toIso: <A, B>(I: Isomorphism<A, B>) => Iso<A, B>
-```
-
-```hs
-toIso :: Isomorphism a b -> Iso a b
 ```
 
 Added in v0.13.0

--- a/docs/modules/JSON.ts.md
+++ b/docs/modules/JSON.ts.md
@@ -38,10 +38,6 @@ Newtype representing stringified JSON.
 export type JSONString = Newtype<JSONStringSymbol, string>
 ```
 
-```hs
-type JSONString = Newtype JSONStringSymbol string
-```
-
 Added in v0.5.0
 
 ## parse
@@ -53,10 +49,6 @@ and is a union of all possible parsed types.
 
 ```ts
 export declare const parse: <E>(f: (e: SyntaxError) => E) => (x: string) => Either<E, Json>
-```
-
-```hs
-parse :: (SyntaxError -> e) -> string -> Either e Json
 ```
 
 **Example**
@@ -87,10 +79,6 @@ Parse a string as JSON, returning an `Option`.
 export declare const parseO: (stringified: string) => Option<unknown>
 ```
 
-```hs
-parseO :: string -> Option unknown
-```
-
 **Example**
 
 ```ts
@@ -114,10 +102,6 @@ Stringify some arbitrary data.
 
 ```ts
 export declare const stringify: <E>(f: (e: TypeError) => E) => (x: unknown) => Either<E, JSONString>
-```
-
-```hs
-stringify :: (TypeError -> e) -> unknown -> Either e JSONString
 ```
 
 **Example**
@@ -148,10 +132,6 @@ Stringify some arbitrary data, returning an `Option`.
 export declare const stringifyO: (data: unknown) => Option<JSONString>
 ```
 
-```hs
-stringifyO :: unknown -> Option JSONString
-```
-
 **Example**
 
 ```ts
@@ -177,10 +157,6 @@ Stringify a primitive value with no possibility of failure.
 export declare const stringifyPrimitive: (x: string | number | boolean | null) => JSONString
 ```
 
-```hs
-stringifyPrimitive :: string | number | boolean | null -> JSONString
-```
-
 **Example**
 
 ```ts
@@ -201,10 +177,6 @@ Unwrap a `JSONString` newtype back to its underlying string representation.
 export declare const unJSONString: (s: JSONString) => string
 ```
 
-```hs
-unJSONString :: JSONString -> string
-```
-
 Added in v0.6.0
 
 ## unstringify
@@ -216,10 +188,6 @@ with the `JSONString` newtype.
 
 ```ts
 export declare const unstringify: (x: JSONString) => unknown
-```
-
-```hs
-unstringify :: JSONString -> unknown
 ```
 
 **Example**

--- a/docs/modules/Lazy.ts.md
+++ b/docs/modules/Lazy.ts.md
@@ -67,10 +67,6 @@ Identity for `Lazy` as applied to `sequenceT`.
 export declare const ApT: Lazy<readonly []>
 ```
 
-```hs
-ApT :: Lazy []
-```
-
 Added in v0.12.0
 
 ## Applicative
@@ -82,10 +78,6 @@ functions that require it.
 
 ```ts
 export declare const Applicative: Applicative1<'Lazy'>
-```
-
-```hs
-Applicative :: Applicative1 "Lazy"
 ```
 
 Added in v0.12.0
@@ -101,10 +93,6 @@ that require it.
 export declare const Apply: Apply1<'Lazy'>
 ```
 
-```hs
-Apply :: Apply1 "Lazy"
-```
-
 Added in v0.12.0
 
 ## Chain
@@ -116,10 +104,6 @@ that require it.
 
 ```ts
 export declare const Chain: Chain1<'Lazy'>
-```
-
-```hs
-Chain :: Chain1 "Lazy"
 ```
 
 Added in v0.12.0
@@ -135,10 +119,6 @@ functions that require it.
 export declare const ChainRec: ChainRec1<'Lazy'>
 ```
 
-```hs
-ChainRec :: ChainRec1 "Lazy"
-```
-
 Added in v0.12.0
 
 ## Do
@@ -149,10 +129,6 @@ Initiate do notation in the context of `Lazy`.
 
 ```ts
 export declare const Do: Lazy<{}>
-```
-
-```hs
-Do :: Lazy {}
 ```
 
 Added in v0.12.0
@@ -168,10 +144,6 @@ functions that require it.
 export declare const Functor: Functor1<'Lazy'>
 ```
 
-```hs
-Functor :: Functor1 "Lazy"
-```
-
 Added in v0.12.0
 
 ## Lazy
@@ -182,10 +154,6 @@ Re-exported from fp-ts for convenience.
 
 ```ts
 export declare const Lazy: any
-```
-
-```hs
-Lazy :: any
 ```
 
 Added in v0.12.0
@@ -201,10 +169,6 @@ that require it.
 export declare const Monad: Monad1<'Lazy'>
 ```
 
-```hs
-Monad :: Monad1 "Lazy"
-```
-
 Added in v0.12.0
 
 ## Pointed
@@ -216,10 +180,6 @@ functions that require it.
 
 ```ts
 export declare const Pointed: Pointed1<'Lazy'>
-```
-
-```hs
-Pointed :: Pointed1 "Lazy"
 ```
 
 Added in v0.12.0
@@ -234,10 +194,6 @@ Typeclass machinery.
 export declare const URI: 'Lazy'
 ```
 
-```hs
-URI :: "Lazy"
-```
-
 Added in v0.12.0
 
 ## URI (type alias)
@@ -248,10 +204,6 @@ Typeclass machinery.
 
 ```ts
 export type URI = typeof URI
-```
-
-```hs
-type URI = typeof URI
 ```
 
 Added in v0.12.0
@@ -266,10 +218,6 @@ Apply a function within a `Lazy`.
 export declare const ap: <A>(fa: Lazy<A>) => <B>(fab: Lazy<(a: A) => B>) => Lazy<B>
 ```
 
-```hs
-ap :: Lazy a -> Lazy (a -> b) -> Lazy b
-```
-
 Added in v0.12.0
 
 ## apFirst
@@ -280,10 +228,6 @@ Sequence actions, discarding the value of the first argument.
 
 ```ts
 export declare const apFirst: <B>(second: Lazy<B>) => <A>(first: Lazy<A>) => Lazy<A>
-```
-
-```hs
-apFirst :: Lazy b -> Lazy a -> Lazy a
 ```
 
 Added in v0.12.0
@@ -301,10 +245,6 @@ export declare const apS: <N, A, B>(
 ) => (fa: Lazy<A>) => Lazy<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```
 
-```hs
-apS :: (Exclude n (keyof a), Lazy b) -> Lazy a -> Lazy { [k in (n | (keyof a))]: k extends (keyof a) ? a[k] : b }
-```
-
 Added in v0.12.0
 
 ## apSecond
@@ -315,10 +255,6 @@ Sequence actions, discarding the value of the second argument.
 
 ```ts
 export declare const apSecond: <B>(second: Lazy<B>) => <A>(first: Lazy<A>) => Lazy<B>
-```
-
-```hs
-apSecond :: Lazy b -> Lazy a -> Lazy b
 ```
 
 Added in v0.12.0
@@ -336,10 +272,6 @@ export declare const bind: <N, A, B>(
 ) => (ma: Lazy<A>) => Lazy<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```
 
-```hs
-bind :: (Exclude n (keyof a), (a -> Lazy b)) -> Lazy a -> Lazy { [k in (n | (keyof a))]: k extends (keyof a) ? a[k] : b }
-```
-
 Added in v0.12.0
 
 ## bindTo
@@ -351,10 +283,6 @@ specified key in do notation.
 
 ```ts
 export declare const bindTo: <N>(name: N) => <A>(fa: Lazy<A>) => Lazy<{ readonly [K in N]: A }>
-```
-
-```hs
-bindTo :: n -> Lazy a -> Lazy { [k in n]: a }
 ```
 
 Added in v0.12.0
@@ -369,10 +297,6 @@ Map and flatten the output of a `Lazy`.
 export declare const chain: <A, B>(f: (a: A) => Lazy<B>) => (ma: Lazy<A>) => Lazy<B>
 ```
 
-```hs
-chain :: (a -> Lazy b) -> Lazy a -> Lazy b
-```
-
 Added in v0.12.0
 
 ## chainFirst
@@ -383,10 +307,6 @@ Like `chain`, but discards the new output.
 
 ```ts
 export declare const chainFirst: <A, B>(f: (a: A) => Lazy<B>) => (first: Lazy<A>) => Lazy<A>
-```
-
-```hs
-chainFirst :: (a -> Lazy b) -> Lazy a -> Lazy a
 ```
 
 Added in v0.12.0
@@ -400,10 +320,6 @@ function application and composition pipelines.
 
 ```ts
 export declare const execute: <A>(x: Lazy<A>) => A
-```
-
-```hs
-execute :: Lazy a -> a
 ```
 
 **Example**
@@ -427,10 +343,6 @@ ordinary value.
 export declare const flap: <A>(a: A) => <B>(fab: Lazy<(a: A) => B>) => Lazy<B>
 ```
 
-```hs
-flap :: a -> Lazy (a -> b) -> Lazy b
-```
-
 Added in v0.12.0
 
 ## flatten
@@ -441,10 +353,6 @@ Flatten a nested `Lazy`.
 
 ```ts
 export declare const flatten: <A>(mma: Lazy<Lazy<A>>) => Lazy<A>
-```
-
-```hs
-flatten :: Lazy (Lazy a) -> Lazy a
 ```
 
 Added in v0.12.0
@@ -460,10 +368,6 @@ use `constant`.
 
 ```ts
 export declare const lazy: <A>(f: () => A) => Lazy<A>
-```
-
-```hs
-lazy :: (() -> a) -> Lazy a
 ```
 
 **Example**
@@ -486,10 +390,6 @@ Map the output of a `Lazy`.
 export declare const map: <A, B>(f: (x: A) => B) => (fa: Lazy<A>) => Lazy<B>
 ```
 
-```hs
-map :: (a -> b) -> Lazy a -> Lazy b
-```
-
 Added in v0.12.0
 
 ## memoize
@@ -500,10 +400,6 @@ Memoize a `Lazy`. Provided the input function is pure, this function is too.
 
 ```ts
 export declare const memoize: <A>(f: Lazy<A>) => Lazy<A>
-```
-
-```hs
-memoize :: Lazy a -> Lazy a
 ```
 
 **Example**
@@ -529,10 +425,6 @@ Raise any value to a `Lazy`.
 export declare const of: <A>(a: A) => Lazy<A>
 ```
 
-```hs
-of :: a -> Lazy a
-```
-
 Added in v0.12.0
 
 ## sequenceArray
@@ -545,10 +437,6 @@ Equivalent to `Array#sequence(Applicative)`.
 export declare const sequenceArray: <A>(arr: readonly Lazy<A>[]) => Lazy<readonly A[]>
 ```
 
-```hs
-sequenceArray :: Array (Lazy a) -> Lazy (Array a)
-```
-
 Added in v2.9.0
 
 ## traverseArray
@@ -559,10 +447,6 @@ Equivalent to `Array#traverse(Applicative)`.
 
 ```ts
 export declare const traverseArray: <A, B>(f: (a: A) => Lazy<B>) => (as: readonly A[]) => Lazy<readonly B[]>
-```
-
-```hs
-traverseArray :: (a -> Lazy b) -> Array a -> Lazy (Array b)
 ```
 
 Added in v0.12.0
@@ -579,10 +463,6 @@ export declare const traverseArrayWithIndex: <A, B>(
 ) => (as: readonly A[]) => Lazy<readonly B[]>
 ```
 
-```hs
-traverseArrayWithIndex :: ((number, a) -> Lazy b) -> Array a -> Lazy (Array b)
-```
-
 Added in v0.12.0
 
 ## traverseReadonlyArrayWithIndex
@@ -597,10 +477,6 @@ export declare const traverseReadonlyArrayWithIndex: <A, B>(
 ) => (as: readonly A[]) => Lazy<readonly B[]>
 ```
 
-```hs
-traverseReadonlyArrayWithIndex :: ((number, a) -> Lazy b) -> Array a -> Lazy (Array b)
-```
-
 Added in v0.12.0
 
 ## traverseReadonlyNonEmptyArrayWithIndex
@@ -613,10 +489,6 @@ Equivalent to `ReadonlyNonEmptyArray#traverseWithIndex(Applicative)`.
 export declare const traverseReadonlyNonEmptyArrayWithIndex: <A, B>(
   f: (index: number, a: A) => Lazy<B>
 ) => (as: ReadonlyNonEmptyArray<A>) => Lazy<ReadonlyNonEmptyArray<B>>
-```
-
-```hs
-traverseReadonlyNonEmptyArrayWithIndex :: ((number, a) -> Lazy b) -> ReadonlyNonEmptyArray a -> Lazy (ReadonlyNonEmptyArray b)
 ```
 
 Added in v0.12.0

--- a/docs/modules/Monad.ts.md
+++ b/docs/modules/Monad.ts.md
@@ -53,15 +53,6 @@ export declare function allPassM<M extends URIS>(
 ): <A>(f: Array<(x: A) => Kind<M, boolean>>) => (x: A) => Kind<M, boolean>
 ```
 
-```hs
-allPassM :: m extends URIS4 => Monad4 m -> Array (a -> (Kind4 m s r e boolean)) -> a -> Kind4 m s r e boolean
-allPassM :: m extends URIS3 => ((Monad3 m) -> Array (a -> (Kind3 m r e boolean)) -> a -> Kind3 m r e boolean)
-allPassM :: m extends URIS3 => ((Monad3C m e) -> Array (a -> (Kind3 m r e boolean)) -> a -> Kind3 m r e boolean)
-allPassM :: m extends URIS2 => ((Monad2 m) -> Array (a -> (Kind2 m e boolean)) -> a -> Kind2 m e boolean)
-allPassM :: m extends URIS2 => ((Monad2C m e) -> Array (a -> (Kind2 m e boolean)) -> a -> Kind2 m e boolean)
-allPassM :: m extends URIS => ((Monad1 m) -> Array (a -> (Kind m boolean)) -> a -> Kind m boolean)
-```
-
 **Example**
 
 ```ts
@@ -105,15 +96,6 @@ export declare function andM<M extends URIS>(
 ): (x: Kind<M, boolean>) => (y: Kind<M, boolean>) => Kind<M, boolean>
 ```
 
-```hs
-andM :: m extends URIS4 => Monad4 m -> Kind4 m s r e boolean -> Kind4 m s r e boolean -> Kind4 m s r e boolean
-andM :: m extends URIS3 => ((Monad3 m) -> Kind3 m r e boolean -> Kind3 m r e boolean -> Kind3 m r e boolean)
-andM :: m extends URIS3 => ((Monad3C m e) -> Kind3 m r e boolean -> Kind3 m r e boolean -> Kind3 m r e boolean)
-andM :: m extends URIS2 => ((Monad2 m) -> Kind2 m e boolean -> Kind2 m e boolean -> Kind2 m e boolean)
-andM :: m extends URIS2 => ((Monad2C m e) -> Kind2 m e boolean -> Kind2 m e boolean -> Kind2 m e boolean)
-andM :: m extends URIS => ((Monad1 m) -> Kind m boolean -> Kind m boolean -> Kind m boolean)
-```
-
 **Example**
 
 ```ts
@@ -154,15 +136,6 @@ export declare function anyPassM<M extends URIS2, E>(
 export declare function anyPassM<M extends URIS>(
   M: Monad1<M>
 ): <A>(f: Array<(x: A) => Kind<M, boolean>>) => (x: A) => Kind<M, boolean>
-```
-
-```hs
-anyPassM :: m extends URIS4 => Monad4 m -> Array (a -> (Kind4 m s r e boolean)) -> a -> Kind4 m s r e boolean
-anyPassM :: m extends URIS3 => ((Monad3 m) -> Array (a -> (Kind3 m r e boolean)) -> a -> Kind3 m r e boolean)
-anyPassM :: m extends URIS3 => ((Monad3C m e) -> Array (a -> (Kind3 m r e boolean)) -> a -> Kind3 m r e boolean)
-anyPassM :: m extends URIS2 => ((Monad2 m) -> Array (a -> (Kind2 m e boolean)) -> a -> Kind2 m e boolean)
-anyPassM :: m extends URIS2 => ((Monad2C m e) -> Array (a -> (Kind2 m e boolean)) -> a -> Kind2 m e boolean)
-anyPassM :: m extends URIS => ((Monad1 m) -> Array (a -> (Kind m boolean)) -> a -> Kind m boolean)
 ```
 
 **Example**
@@ -210,15 +183,6 @@ export declare function ifM<M extends URIS>(
 ): (p: Kind<M, boolean>) => <A>(x: Kind<M, A>) => (y: Kind<M, A>) => Kind<M, A>
 ```
 
-```hs
-ifM :: m extends URIS4 => Monad4 m -> Kind4 m s r e boolean -> Kind4 m s r e a -> Kind4 m s r e a -> Kind4 m s r e a
-ifM :: m extends URIS3 => ((Monad3 m) -> Kind3 m r e boolean -> Kind3 m r e a -> Kind3 m r e a -> Kind3 m r e a)
-ifM :: m extends URIS3 => ((Monad3C m e) -> Kind3 m r e boolean -> Kind3 m r e a -> Kind3 m r e a -> Kind3 m r e a)
-ifM :: m extends URIS2 => ((Monad2 m) -> Kind2 m e boolean -> Kind2 m e a -> Kind2 m e a -> Kind2 m e a)
-ifM :: m extends URIS2 => ((Monad2C m e) -> Kind2 m e boolean -> Kind2 m e a -> Kind2 m e a -> Kind2 m e a)
-ifM :: m extends URIS => ((Monad1 m) -> Kind m boolean -> Kind m a -> Kind m a -> Kind m a)
-```
-
 **Example**
 
 ```ts
@@ -258,15 +222,6 @@ export declare function nonePassM<M extends URIS2, E>(
 export declare function nonePassM<M extends URIS>(
   M: Monad1<M>
 ): <A>(f: Array<(x: A) => Kind<M, boolean>>) => (x: A) => Kind<M, boolean>
-```
-
-```hs
-nonePassM :: m extends URIS4 => Monad4 m -> Array (a -> (Kind4 m s r e boolean)) -> a -> Kind4 m s r e boolean
-nonePassM :: m extends URIS3 => ((Monad3 m) -> Array (a -> (Kind3 m r e boolean)) -> a -> Kind3 m r e boolean)
-nonePassM :: m extends URIS3 => ((Monad3C m e) -> Array (a -> (Kind3 m r e boolean)) -> a -> Kind3 m r e boolean)
-nonePassM :: m extends URIS2 => ((Monad2 m) -> Array (a -> (Kind2 m e boolean)) -> a -> Kind2 m e boolean)
-nonePassM :: m extends URIS2 => ((Monad2C m e) -> Array (a -> (Kind2 m e boolean)) -> a -> Kind2 m e boolean)
-nonePassM :: m extends URIS => ((Monad1 m) -> Array (a -> (Kind m boolean)) -> a -> Kind m boolean)
 ```
 
 **Example**
@@ -310,15 +265,6 @@ export declare function orM<M extends URIS2, E>(
 export declare function orM<M extends URIS>(
   M: Monad1<M>
 ): (x: Kind<M, boolean>) => (y: Kind<M, boolean>) => Kind<M, boolean>
-```
-
-```hs
-orM :: m extends URIS4 => Monad4 m -> Kind4 m s r e boolean -> Kind4 m s r e boolean -> Kind4 m s r e boolean
-orM :: m extends URIS3 => ((Monad3 m) -> Kind3 m r e boolean -> Kind3 m r e boolean -> Kind3 m r e boolean)
-orM :: m extends URIS3 => ((Monad3C m e) -> Kind3 m r e boolean -> Kind3 m r e boolean -> Kind3 m r e boolean)
-orM :: m extends URIS2 => ((Monad2 m) -> Kind2 m e boolean -> Kind2 m e boolean -> Kind2 m e boolean)
-orM :: m extends URIS2 => ((Monad2C m e) -> Kind2 m e boolean -> Kind2 m e boolean -> Kind2 m e boolean)
-orM :: m extends URIS => ((Monad1 m) -> Kind m boolean -> Kind m boolean -> Kind m boolean)
 ```
 
 **Example**

--- a/docs/modules/Monoid.ts.md
+++ b/docs/modules/Monoid.ts.md
@@ -34,10 +34,6 @@ to `memptyWhen`. The lazy value is evaluated only if the condition passes.
 export declare const memptyUnless: <A>(M: Monoid<A>) => (x: boolean) => (y: Lazy<A>) => A
 ```
 
-```hs
-memptyUnless :: Monoid a -> boolean -> Lazy a -> a
-```
-
 **Example**
 
 ```ts
@@ -65,10 +61,6 @@ to `memptyUnless`. The lazy value is evaluated only if the condition passes.
 
 ```ts
 export declare const memptyWhen: <A>(M: Monoid<A>) => (x: boolean) => (y: Lazy<A>) => A
-```
-
-```hs
-memptyWhen :: Monoid a -> boolean -> Lazy a -> a
 ```
 
 **Example**
@@ -109,15 +101,6 @@ export declare function toMonoid<F extends URIS3, E>(
 export declare function toMonoid<F extends URIS2>(F: Foldable2<F>): <A, E>(G: Monoid<A>) => (x: Kind2<F, E, A>) => A
 export declare function toMonoid<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(G: Monoid<A>) => (x: Kind2<F, E, A>) => A
 export declare function toMonoid<F extends URIS>(F: Foldable1<F>): <A>(G: Monoid<A>) => (x: Kind<F, A>) => A
-```
-
-```hs
-toMonoid :: f extends URIS4 => Foldable4 f -> Monoid a -> Kind4 f s r e a -> a
-toMonoid :: f extends URIS3 => ((Foldable3 f) -> Monoid a -> Kind3 f r e a -> a)
-toMonoid :: f extends URIS3 => ((Foldable3C f e) -> Monoid a -> Kind3 f r e a -> a)
-toMonoid :: f extends URIS2 => ((Foldable2 f) -> Monoid a -> Kind2 f e a -> a)
-toMonoid :: f extends URIS2 => ((Foldable2C f e) -> Monoid a -> Kind2 f e a -> a)
-toMonoid :: f extends URIS => ((Foldable1 f) -> Monoid a -> Kind f a -> a)
 ```
 
 **Example**

--- a/docs/modules/Newtype.ts.md
+++ b/docs/modules/Newtype.ts.md
@@ -38,10 +38,6 @@ newtypes.
 export declare const over: <A>(f: Endomorphism<A>) => <B extends Newtype<unknown, A>>(x: B) => B
 ```
 
-```hs
-over :: b extends (Newtype unknown a) => Endomorphism a -> b -> b
-```
-
 **Example**
 
 ```ts
@@ -78,14 +74,6 @@ export declare function overF<F>(
 ): <A>(f: (x: A) => HKT<F, A>) => <B extends Newtype<unknown, A>>(x: B) => HKT<F, B>
 ```
 
-```hs
-overF :: f extends URIS4, b extends (Newtype unknown a) => Functor4 f -> (a -> Kind4 f s r e a) -> b -> Kind4 f s r e b
-overF :: f extends URIS3, b extends (Newtype unknown a) => Functor3 f -> (a -> Kind3 f r e a) -> b -> Kind3 f r e b
-overF :: f extends URIS2, b extends (Newtype unknown a) => Functor2 f -> (a -> Kind2 f e a) -> b -> Kind2 f e b
-overF :: f extends URIS, b extends (Newtype unknown a) => Functor1 f -> (a -> Kind f a) -> b -> Kind f b
-overF :: b extends (Newtype unknown a) => Functor f -> (a -> HKT f a) -> b -> HKT f b
-```
-
 **Example**
 
 ```ts
@@ -112,10 +100,6 @@ Pack a value into a newtype.
 export declare const pack: <A extends Newtype<unknown, unknown> = never>(x: A['_A']) => A
 ```
 
-```hs
-pack :: a extends (Newtype unknown unknown) => a["_A"] -> a
-```
-
 **Example**
 
 ```ts
@@ -135,10 +119,6 @@ Unpack a value from a newtype.
 
 ```ts
 export declare const unpack: <A extends Newtype<unknown, unknown>>(x: A) => A['_A']
-```
-
-```hs
-unpack :: a extends (Newtype unknown unknown) => a -> a["_A"]
 ```
 
 **Example**

--- a/docs/modules/NonEmptyString.ts.md
+++ b/docs/modules/NonEmptyString.ts.md
@@ -51,10 +51,6 @@ Added in v0.15.0
 export declare const Eq: Eq<NonEmptyString>
 ```
 
-```hs
-Eq :: Eq NonEmptyString
-```
-
 Added in v0.15.0
 
 ## NonEmptyString (type alias)
@@ -69,10 +65,6 @@ as unlike `NonEmptyArray` it's only protected by a smart constructor.
 export type NonEmptyString = Newtype<NonEmptyStringSymbol, string>
 ```
 
-```hs
-type NonEmptyString = Newtype NonEmptyStringSymbol string
-```
-
 Added in v0.15.0
 
 ## Ord
@@ -83,10 +75,6 @@ Added in v0.15.0
 
 ```ts
 export declare const Ord: Ord<NonEmptyString>
-```
-
-```hs
-Ord :: Ord NonEmptyString
 ```
 
 Added in v0.15.0
@@ -101,10 +89,6 @@ Added in v0.15.0
 export declare const Semigroup: Semigroup<NonEmptyString>
 ```
 
-```hs
-Semigroup :: Semigroup NonEmptyString
-```
-
 Added in v0.15.0
 
 ## Show
@@ -115,10 +99,6 @@ Added in v0.15.0
 
 ```ts
 export declare const Show: Show<NonEmptyString>
-```
-
-```hs
-Show :: Show NonEmptyString
 ```
 
 Added in v0.15.0
@@ -133,10 +113,6 @@ Append a string to a `NonEmptyString`.
 export declare const append: (x: string) => Endomorphism<NonEmptyString>
 ```
 
-```hs
-append :: string -> Endomorphism NonEmptyString
-```
-
 Added in v0.15.0
 
 ## fromNumber
@@ -147,10 +123,6 @@ Safely derive a `NonEmptyString` from any number.
 
 ```ts
 export declare const fromNumber: (x: number) => NonEmptyString
-```
-
-```hs
-fromNumber :: number -> NonEmptyString
 ```
 
 Added in v0.15.0
@@ -177,10 +149,6 @@ Get the first character in a `NonEmptyString`.
 export declare const head: Endomorphism<NonEmptyString>
 ```
 
-```hs
-head :: Endomorphism NonEmptyString
-```
-
 Added in v0.15.0
 
 ## last
@@ -191,10 +159,6 @@ Get the last character in a `NonEmptyString`.
 
 ```ts
 export declare const last: Endomorphism<NonEmptyString>
-```
-
-```hs
-last :: Endomorphism NonEmptyString
 ```
 
 Added in v0.15.0
@@ -209,10 +173,6 @@ Prepend a string to a `NonEmptyString`.
 export declare const prepend: (x: string) => Endomorphism<NonEmptyString>
 ```
 
-```hs
-prepend :: string -> Endomorphism NonEmptyString
-```
-
 Added in v0.15.0
 
 ## reverse
@@ -223,10 +183,6 @@ Reverse a `NonEmptyString`.
 
 ```ts
 export declare const reverse: Endomorphism<NonEmptyString>
-```
-
-```hs
-reverse :: Endomorphism NonEmptyString
 ```
 
 Added in v0.15.0
@@ -242,10 +198,6 @@ with the same outer value.
 export declare const surround: (x: string) => Endomorphism<NonEmptyString>
 ```
 
-```hs
-surround :: string -> Endomorphism NonEmptyString
-```
-
 Added in v0.15.0
 
 ## toLowerCase
@@ -256,10 +208,6 @@ Convert a `NonEmptyString` to lowercase.
 
 ```ts
 export declare const toLowerCase: Endomorphism<NonEmptyString>
-```
-
-```hs
-toLowerCase :: Endomorphism NonEmptyString
 ```
 
 Added in v0.15.0
@@ -274,10 +222,6 @@ An alias of `unNonEmptyString`.
 export declare const toString: (x: NonEmptyString) => string
 ```
 
-```hs
-toString :: NonEmptyString -> string
-```
-
 Added in v0.15.0
 
 ## toUpperCase
@@ -288,10 +232,6 @@ Convert a `NonEmptyString` to uppercase.
 
 ```ts
 export declare const toUpperCase: Endomorphism<NonEmptyString>
-```
-
-```hs
-toUpperCase :: Endomorphism NonEmptyString
 ```
 
 Added in v0.15.0
@@ -307,10 +247,6 @@ representation.
 export declare const unNonEmptyString: (x: NonEmptyString) => string
 ```
 
-```hs
-unNonEmptyString :: NonEmptyString -> string
-```
-
 Added in v0.15.0
 
 ## unsafeFromString
@@ -322,10 +258,6 @@ Try to use `fromString` instead.
 
 ```ts
 export declare const unsafeFromString: (x: string) => NonEmptyString
-```
-
-```hs
-unsafeFromString :: string -> NonEmptyString
 ```
 
 Added in v0.15.0

--- a/docs/modules/Number.ts.md
+++ b/docs/modules/Number.ts.md
@@ -49,10 +49,6 @@ Add two numbers together.
 export declare const add: (x: number) => Endomorphism<number>
 ```
 
-```hs
-add :: number -> Endomorphism number
-```
-
 **Example**
 
 ```ts
@@ -71,10 +67,6 @@ Decrement a number.
 
 ```ts
 export declare const decrement: Endomorphism<number>
-```
-
-```hs
-decrement :: Endomorphism number
 ```
 
 **Example**
@@ -98,10 +90,6 @@ _divisor_).
 export declare const divide: (divisor: number) => Endomorphism<number>
 ```
 
-```hs
-divide :: number -> Endomorphism number
-```
-
 **Example**
 
 ```ts
@@ -121,10 +109,6 @@ Convert a string to a floating point number.
 
 ```ts
 export declare const floatFromString: (x: string) => Option<number>
-```
-
-```hs
-floatFromString :: string -> Option number
 ```
 
 **Example**
@@ -149,10 +133,6 @@ Convert a string to a number.
 export declare const fromString: (string: string) => Option<number>
 ```
 
-```hs
-fromString :: string -> Option number
-```
-
 **Example**
 
 ```ts
@@ -173,10 +153,6 @@ Convert a string to a number.
 
 ```ts
 export declare const fromStringWithRadix: (radix: number) => (string: string) => Option<number>
-```
-
-```hs
-fromStringWithRadix :: number -> string -> Option number
 ```
 
 **Example**
@@ -201,10 +177,6 @@ Increment a number.
 export declare const increment: Endomorphism<number>
 ```
 
-```hs
-increment :: Endomorphism number
-```
-
 **Example**
 
 ```ts
@@ -223,10 +195,6 @@ Check if a number is finite.
 
 ```ts
 export declare const isFinite: Predicate<number>
-```
-
-```hs
-isFinite :: Predicate number
 ```
 
 **Example**
@@ -252,10 +220,6 @@ Check if a number is negative.
 export declare const isNegative: Predicate<number>
 ```
 
-```hs
-isNegative :: Predicate number
-```
-
 **Example**
 
 ```ts
@@ -276,10 +240,6 @@ Check if a number is non-negative.
 
 ```ts
 export declare const isNonNegative: Predicate<number>
-```
-
-```hs
-isNonNegative :: Predicate number
 ```
 
 **Example**
@@ -304,10 +264,6 @@ Check if a number is non-positive.
 export declare const isNonPositive: Predicate<number>
 ```
 
-```hs
-isNonPositive :: Predicate number
-```
-
 **Example**
 
 ```ts
@@ -328,10 +284,6 @@ Check if a number is positive.
 
 ```ts
 export declare const isPositive: Predicate<number>
-```
-
-```hs
-isPositive :: Predicate number
 ```
 
 **Example**
@@ -355,10 +307,6 @@ doing is checking whether or not the number is `NaN`.
 
 ```ts
 export declare const isValid: Predicate<number>
-```
-
-```hs
-isValid :: Predicate number
 ```
 
 **Example**
@@ -385,10 +333,6 @@ Calculate the modulus. See also `rem`.
 export declare const mod: (divisor: number) => Endomorphism<number>
 ```
 
-```hs
-mod :: number -> Endomorphism number
-```
-
 **Example**
 
 ```ts
@@ -411,10 +355,6 @@ Multiply two numbers together.
 export declare const multiply: (x: number) => Endomorphism<number>
 ```
 
-```hs
-multiply :: number -> Endomorphism number
-```
-
 **Example**
 
 ```ts
@@ -433,10 +373,6 @@ Unary negation.
 
 ```ts
 export declare const negate: Endomorphism<number>
-```
-
-```hs
-negate :: Endomorphism number
 ```
 
 **Example**
@@ -458,10 +394,6 @@ Calculates the remainder. See also `mod`.
 
 ```ts
 export declare const rem: (divisor: number) => Endomorphism<number>
-```
-
-```hs
-rem :: number -> Endomorphism number
 ```
 
 **Example**
@@ -487,10 +419,6 @@ _minuend_).
 export declare const subtract: (subtrahend: number) => Endomorphism<number>
 ```
 
-```hs
-subtract :: number -> Endomorphism number
-```
-
 **Example**
 
 ```ts
@@ -511,10 +439,6 @@ nearest safe finite number.
 
 ```ts
 export declare const toFinite: Endomorphism<number>
-```
-
-```hs
-toFinite :: Endomorphism number
 ```
 
 **Example**

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -40,10 +40,6 @@ the `Option` values, short-circuiting upon a non-empty value. Useful given
 export declare const altAllBy: <A, B>(fs: ((x: A) => Option<B>)[]) => (x: A) => Option<B>
 ```
 
-```hs
-altAllBy :: Array ((a -> Option b)) -> a -> Option b
-```
-
 **Example**
 
 ```ts
@@ -69,10 +65,6 @@ an `Option` value.
 
 ```ts
 export declare const invert: <A>(eq: Eq<A>) => (val: A) => Endomorphism<Option<A>>
-```
-
-```hs
-invert :: Eq a -> a -> Endomorphism (Option a)
 ```
 
 **Example**
@@ -102,10 +94,6 @@ Conditionally returns the provided `Option` or `None`. The dual to
 export declare const memptyUnless: (x: boolean) => <A>(m: Lazy<Option<A>>) => Option<A>
 ```
 
-```hs
-memptyUnless :: boolean -> Lazy (Option a) -> Option a
-```
-
 **Example**
 
 ```ts
@@ -130,10 +118,6 @@ Conditionally returns the provided `Option` or `None`. The dual to
 
 ```ts
 export declare const memptyWhen: (x: boolean) => <A>(m: Lazy<Option<A>>) => Option<A>
-```
-
-```hs
-memptyWhen :: boolean -> Lazy (Option a) -> Option a
 ```
 
 **Example**
@@ -164,10 +148,6 @@ standard `None` constructor.
 export declare const noneAs: <A>() => Option<A>
 ```
 
-```hs
-noneAs :: () -> Option a
-```
-
 **Example**
 
 ```ts
@@ -188,10 +168,6 @@ evaluated only if the condition passes.
 
 ```ts
 export declare const pureIf: (x: boolean) => <A>(y: Lazy<A>) => Option<A>
-```
-
-```hs
-pureIf :: boolean -> Lazy a -> Option a
 ```
 
 **Example**
@@ -219,10 +195,6 @@ Extracts monoidal identity if `None`.
 export declare const toMonoid: <A>(G: Monoid<A>) => (x: Option<A>) => A
 ```
 
-```hs
-toMonoid :: Monoid a -> Option a -> a
-```
-
 **Example**
 
 ```ts
@@ -246,10 +218,6 @@ Unwrap the value from within an `Option`, throwing if `None`.
 
 ```ts
 export declare const unsafeUnwrap: <A>(x: Option<A>) => A
-```
-
-```hs
-unsafeUnwrap :: Option a -> a
 ```
 
 **Example**

--- a/docs/modules/Ordering.ts.md
+++ b/docs/modules/Ordering.ts.md
@@ -33,10 +33,6 @@ Alias for the notion of "equal to" in `Ordering`.
 export declare const EQ: Ordering
 ```
 
-```hs
-EQ :: Ordering
-```
-
 Added in v0.12.0
 
 ## GT
@@ -49,10 +45,6 @@ Alias for the notion of "greater than" in `Ordering`.
 export declare const GT: Ordering
 ```
 
-```hs
-GT :: Ordering
-```
-
 Added in v0.12.0
 
 ## LT
@@ -63,10 +55,6 @@ Alias for the notion of "less than" in `Ordering`.
 
 ```ts
 export declare const LT: Ordering
-```
-
-```hs
-LT :: Ordering
 ```
 
 Added in v0.12.0

--- a/docs/modules/Predicate.ts.md
+++ b/docs/modules/Predicate.ts.md
@@ -35,10 +35,6 @@ argument passes all of the predicates.
 export declare const allPass: <A>(fs: Predicate<A>[]) => Predicate<A>
 ```
 
-```hs
-allPass :: Array (Predicate a) -> Predicate a
-```
-
 **Example**
 
 ```ts
@@ -66,10 +62,6 @@ argument passes any of the predicates.
 export declare const anyPass: <A>(fs: Predicate<A>[]) => Predicate<A>
 ```
 
-```hs
-anyPass :: Array (Predicate a) -> Predicate a
-```
-
 **Example**
 
 ```ts
@@ -95,10 +87,6 @@ argument passes none of the predicates.
 
 ```ts
 export declare const nonePass: <A>(fs: Predicate<A>[]) => Predicate<A>
-```
-
-```hs
-nonePass :: Array (Predicate a) -> Predicate a
 ```
 
 **Example**

--- a/docs/modules/Random.ts.md
+++ b/docs/modules/Random.ts.md
@@ -32,10 +32,6 @@ well.
 export declare const randomExtract: <A>(xs: NonEmptyArray<A>) => IO<[A, A[]]>
 ```
 
-```hs
-randomExtract :: NonEmptyArray a -> IO [a, (Array a)]
-```
-
 **Example**
 
 ```ts

--- a/docs/modules/Reader.ts.md
+++ b/docs/modules/Reader.ts.md
@@ -31,10 +31,6 @@ Runs a Reader and extracts the final value from it.
 export declare const runReader: <R, A>(r: R) => (reader: Reader<R, A>) => A
 ```
 
-```hs
-runReader :: r -> Reader r a -> a
-```
-
 **Example**
 
 ```ts

--- a/docs/modules/ReaderEither.ts.md
+++ b/docs/modules/ReaderEither.ts.md
@@ -31,10 +31,6 @@ Runs a ReaderEither and extracts the final Either from it.
 export declare const runReaderEither: <R, E, A>(r: R) => (reader: ReaderEither<R, E, A>) => Either<E, A>
 ```
 
-```hs
-runReaderEither :: r -> ReaderEither r e a -> Either e a
-```
-
 **Example**
 
 ```ts

--- a/docs/modules/ReaderTask.ts.md
+++ b/docs/modules/ReaderTask.ts.md
@@ -31,10 +31,6 @@ Runs a ReaderTask and extracts the final Task from it.
 export declare const runReaderTask: <R, A>(r: R) => (reader: ReaderTask<R, A>) => Task<A>
 ```
 
-```hs
-runReaderTask :: r -> ReaderTask r a -> Task a
-```
-
 **Example**
 
 ```ts

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -83,15 +83,6 @@ export declare function allM<M extends URIS2, E>(
 export declare function allM<M extends URIS>(M: Monad1<M>): (xs: ReadonlyArray<Kind<M, boolean>>) => Kind<M, boolean>
 ```
 
-```hs
-allM :: m extends URIS4 => Monad4 m -> ReadonlyArray (Kind4 m s r e boolean) -> Kind4 m s r e boolean
-allM :: m extends URIS3 => ((Monad3 m) -> ReadonlyArray (Kind3 m r e boolean) -> Kind3 m r e boolean)
-allM :: m extends URIS3 => ((Monad3C m e) -> ReadonlyArray (Kind3 m r e boolean) -> Kind3 m r e boolean)
-allM :: m extends URIS2 => ((Monad2 m) -> ReadonlyArray (Kind2 m e boolean) -> Kind2 m e boolean)
-allM :: m extends URIS2 => ((Monad2C m e) -> ReadonlyArray (Kind2 m e boolean) -> Kind2 m e boolean)
-allM :: m extends URIS => ((Monad1 m) -> ReadonlyArray (Kind m boolean) -> Kind m boolean)
-```
-
 **Example**
 
 ```ts
@@ -133,15 +124,6 @@ export declare function anyM<M extends URIS2, E>(
 export declare function anyM<M extends URIS>(M: Monad1<M>): (xs: ReadonlyArray<Kind<M, boolean>>) => Kind<M, boolean>
 ```
 
-```hs
-anyM :: m extends URIS4 => Monad4 m -> ReadonlyArray (Kind4 m s r e boolean) -> Kind4 m s r e boolean
-anyM :: m extends URIS3 => ((Monad3 m) -> ReadonlyArray (Kind3 m r e boolean) -> Kind3 m r e boolean)
-anyM :: m extends URIS3 => ((Monad3C m e) -> ReadonlyArray (Kind3 m r e boolean) -> Kind3 m r e boolean)
-anyM :: m extends URIS2 => ((Monad2 m) -> ReadonlyArray (Kind2 m e boolean) -> Kind2 m e boolean)
-anyM :: m extends URIS2 => ((Monad2C m e) -> ReadonlyArray (Kind2 m e boolean) -> Kind2 m e boolean)
-anyM :: m extends URIS => ((Monad1 m) -> ReadonlyArray (Kind m boolean) -> Kind m boolean)
-```
-
 **Example**
 
 ```ts
@@ -170,10 +152,6 @@ If `n` is greater than the length of the array, an empty array is returned.
 
 ```ts
 export declare const aperture: (n: number) => <A>(xs: readonly A[]) => readonly (readonly A[])[]
-```
-
-```hs
-aperture :: number -> Array a -> Array (Array a)
 ```
 
 **Example**
@@ -208,10 +186,6 @@ possible ordered combination of the two input arrays.
 export declare const cartesian: <A>(xs: readonly A[]) => <B>(ys: readonly B[]) => readonly [A, B][]
 ```
 
-```hs
-cartesian :: Array a -> Array b -> Array [a, b]
-```
-
 **Example**
 
 ```ts
@@ -237,10 +211,6 @@ Map each item of an array to a key, and count how many map to each key.
 
 ```ts
 export declare const countBy: <A>(f: (x: A) => string) => (xs: readonly A[]) => Record<string, number>
-```
-
-```hs
-countBy :: (a -> string) -> Array a -> Record string number
 ```
 
 **Example**
@@ -279,10 +249,6 @@ If `n` is a float, it will be rounded down to the nearest integer.
 export declare const dropAt: (i: number) => (n: number) => <A>(xs: readonly A[]) => Option<readonly A[]>
 ```
 
-```hs
-dropAt :: number -> number -> Array a -> Option (Array a)
-```
-
 **Example**
 
 ```ts
@@ -306,10 +272,6 @@ Filter a list, removing any elements that repeat that directly precede them.
 export declare const dropRepeats: <A>(eq: Eq<A>) => Endomorphism<readonly A[]>
 ```
 
-```hs
-dropRepeats :: Eq a -> Endomorphism (Array a)
-```
-
 **Example**
 
 ```ts
@@ -330,10 +292,6 @@ which all elements satisfy the specified predicate, creating a new array.
 
 ```ts
 export declare const dropRightWhile: <A>(f: Predicate<A>) => <B extends A>(xs: readonly B[]) => readonly B[]
-```
-
-```hs
-dropRightWhile :: b extends a => Predicate a -> Array b -> Array b
 ```
 
 **Example**
@@ -360,10 +318,6 @@ Like `fp-ts/ReadonlyArray::elem` but flipped, which the "V" suffix denotes.
 export declare const elemV: <A>(eq: Eq<A>) => (xs: readonly A[]) => Predicate<A>
 ```
 
-```hs
-elemV :: Eq a -> Array a -> Predicate a
-```
-
 **Example**
 
 ```ts
@@ -386,10 +340,6 @@ Check if an array ends with the specified subarray.
 
 ```ts
 export declare const endsWith: <A>(eq: Eq<A>) => (end: readonly A[]) => Predicate<readonly A[]>
-```
-
-```hs
-endsWith :: Eq a -> Array a -> Predicate (Array a)
 ```
 
 **Example**
@@ -415,10 +365,6 @@ the remaining array. Returns `None` if the index is out of bounds.
 
 ```ts
 export declare const extractAt: (i: number) => <A>(xs: readonly A[]) => Option<[A, readonly A[]]>
-```
-
-```hs
-extractAt :: number -> Array a -> Option [a, (Array a)]
 ```
 
 **Example**
@@ -466,15 +412,6 @@ export declare function filterA<F>(
 ): <A>(p: (x: A) => HKT<F, boolean>) => (xs: ReadonlyArray<A>) => HKT<F, ReadonlyArray<A>>
 ```
 
-```hs
-filterA :: f extends URIS4 => Applicative4 f -> (a -> Kind4 f s r e boolean) -> ReadonlyArray a -> Kind4 f s r e (ReadonlyArray a)
-filterA :: f extends URIS3 => ((Applicative3 f) -> (a -> Kind3 f r e boolean) -> ReadonlyArray a -> Kind3 f r e (ReadonlyArray a))
-filterA :: f extends URIS2 => ((Applicative2 f) -> (a -> Kind2 f e boolean) -> ReadonlyArray a -> Kind2 f e (ReadonlyArray a))
-filterA :: f extends URIS2 => ((Applicative2C f e) -> (a -> Kind2 f e boolean) -> ReadonlyArray a -> Kind2 f e (ReadonlyArray a))
-filterA :: f extends URIS => ((Applicative1 f) -> (a -> Kind f boolean) -> ReadonlyArray a -> Kind f (ReadonlyArray a))
-filterA :: ((Applicative f) -> (a -> HKT f boolean) -> ReadonlyArray a -> HKT f (ReadonlyArray a))
-```
-
 **Example**
 
 ```ts
@@ -501,10 +438,6 @@ Convert an `Iterable` to a `ReadonlyArray`.
 export declare const fromIterable: <A>(xs: Iterable<A>) => readonly A[]
 ```
 
-```hs
-fromIterable :: Iterable a -> Array a
-```
-
 **Example**
 
 ```ts
@@ -525,10 +458,6 @@ and `getEq` should be preferred on ordered data.
 
 ```ts
 export declare const getDisorderedEq: <A>(ordA: Ord<A>) => Eq<readonly A[]>
-```
-
-```hs
-getDisorderedEq :: Ord a -> Eq (Array a)
 ```
 
 **Example**
@@ -562,10 +491,6 @@ export declare const insertMany: (
 ) => <A>(xs: ReadonlyNonEmptyArray<A>) => (ys: readonly A[]) => Option<ReadonlyNonEmptyArray<A>>
 ```
 
-```hs
-insertMany :: number -> ReadonlyNonEmptyArray a -> Array a -> Option (ReadonlyNonEmptyArray a)
-```
-
 **Example**
 
 ```ts
@@ -589,10 +514,6 @@ separator.
 
 ```ts
 export declare const join: (x: string) => (ys: ReadonlyArray<string>) => string
-```
-
-```hs
-join :: string -> ReadonlyArray string -> string
 ```
 
 **Example**
@@ -619,10 +540,6 @@ Obtain the maximum value from a non-empty array.
 export declare const maximum: <A>(ord: Ord<A>) => (xs: ReadonlyNonEmptyArray<A>) => A
 ```
 
-```hs
-maximum :: Ord a -> ReadonlyNonEmptyArray a -> a
-```
-
 **Example**
 
 ```ts
@@ -642,10 +559,6 @@ Calculate the mean of an array of numbers.
 
 ```ts
 export declare const mean: (xs: ReadonlyNonEmptyArray<number>) => number
-```
-
-```hs
-mean :: ReadonlyNonEmptyArray number -> number
 ```
 
 **Example**
@@ -668,10 +581,6 @@ Calculate the median of an array of numbers.
 export declare const median: (xs: ReadonlyNonEmptyArray<number>) => number
 ```
 
-```hs
-median :: ReadonlyNonEmptyArray number -> number
-```
-
 **Example**
 
 ```ts
@@ -691,10 +600,6 @@ Obtain the minimum value from a non-empty array.
 
 ```ts
 export declare const minimum: <A>(ord: Ord<A>) => (xs: ReadonlyNonEmptyArray<A>) => A
-```
-
-```hs
-minimum :: Ord a -> ReadonlyNonEmptyArray a -> a
 ```
 
 **Example**
@@ -720,10 +625,6 @@ If both indices are the same, the array is returned unchanged.
 
 ```ts
 export declare const moveFrom: (from: number) => (to: number) => <A>(xs: readonly A[]) => Option<readonly A[]>
-```
-
-```hs
-moveFrom :: number -> number -> Array a -> Option (Array a)
 ```
 
 **Example**
@@ -755,10 +656,6 @@ If both indices are the same, the array is returned unchanged.
 export declare const moveTo: (x: number) => (y: number) => <A>(xs: readonly A[]) => Option<readonly A[]>
 ```
 
-```hs
-moveTo :: number -> number -> Array a -> Option (Array a)
-```
-
 **Example**
 
 ```ts
@@ -782,10 +679,6 @@ Check if a predicate does not hold for any array member.
 
 ```ts
 export declare const none: <A>(f: Predicate<A>) => Predicate<readonly A[]>
-```
-
-```hs
-none :: Predicate a -> Predicate (Array a)
 ```
 
 **Example**
@@ -817,10 +710,6 @@ the remaining items, sans the match (if any), are returned as well.
 export declare const pluckFirst: <A>(p: Predicate<A>) => (xs: readonly A[]) => [Option<A>, readonly A[]]
 ```
 
-```hs
-pluckFirst :: Predicate a -> Array a -> [Option a, Array a]
-```
-
 **Example**
 
 ```ts
@@ -847,10 +736,6 @@ Multiplies together all the numbers in the input array.
 export declare const product: (xs: ReadonlyArray<number>) => number
 ```
 
-```hs
-product :: ReadonlyArray number -> number
-```
-
 **Example**
 
 ```ts
@@ -875,10 +760,6 @@ short-circuits and returns the current accumulator value.
 export declare const reduceRightWhile: <A>(
   p: Predicate<A>
 ) => <B>(f: (x: A) => (y: B) => B) => (x: B) => (ys: readonly A[]) => B
-```
-
-```hs
-reduceRightWhile :: Predicate a -> (a -> b -> b) -> b -> Array a -> b
 ```
 
 **Example**
@@ -910,10 +791,6 @@ export declare const reduceWhile: <A>(
 ) => <B>(f: (x: A) => (y: B) => B) => (x: B) => (ys: readonly A[]) => B
 ```
 
-```hs
-reduceWhile :: Predicate a -> (a -> b -> b) -> b -> Array a -> b
-```
-
 **Example**
 
 ```ts
@@ -938,10 +815,6 @@ thought of as the inverse of ordinary array filtering.
 
 ```ts
 export declare const reject: <A>(f: Predicate<A>) => <B extends A>(xs: readonly B[]) => readonly B[]
-```
-
-```hs
-reject :: b extends a => Predicate a -> Array b -> Array b
 ```
 
 **Example**
@@ -970,10 +843,6 @@ This is merely a functional wrapper around `Array.prototype.slice`.
 export declare const slice: (start: number) => (end: number) => <A>(xs: readonly A[]) => readonly A[]
 ```
 
-```hs
-slice :: number -> number -> Array a -> Array a
-```
-
 **Example**
 
 ```ts
@@ -997,10 +866,6 @@ Check if an array starts with the specified subarray.
 
 ```ts
 export declare const startsWith: <A>(eq: Eq<A>) => (start: readonly A[]) => Predicate<readonly A[]>
-```
-
-```hs
-startsWith :: Eq a -> Array a -> Predicate (Array a)
 ```
 
 **Example**
@@ -1027,10 +892,6 @@ Adds together all the numbers in the input array.
 export declare const sum: (xs: ReadonlyArray<number>) => number
 ```
 
-```hs
-sum :: ReadonlyArray number -> number
-```
-
 **Example**
 
 ```ts
@@ -1052,10 +913,6 @@ duplicate values present only in one input array are maintained.
 
 ```ts
 export declare const symmetricDifference: <A>(eq: Eq<A>) => (xs: readonly A[]) => Endomorphism<readonly A[]>
-```
-
-```hs
-symmetricDifference :: Eq a -> Array a -> Endomorphism (Array a)
 ```
 
 **Example**
@@ -1081,10 +938,6 @@ which all elements satisfy the specified predicate, creating a new array.
 export declare const takeRightWhile: <A>(f: Predicate<A>) => <B extends A>(xs: readonly B[]) => readonly B[]
 ```
 
-```hs
-takeRightWhile :: b extends a => Predicate a -> Array b -> Array b
-```
-
 **Example**
 
 ```ts
@@ -1108,10 +961,6 @@ than the following rows, their elements are skipped.
 
 ```ts
 export declare const transpose: <A>(xs: readonly (readonly A[])[]) => readonly (readonly A[])[]
-```
-
-```hs
-transpose :: Array (Array a) -> Array (Array a)
 ```
 
 **Example**
@@ -1158,10 +1007,6 @@ the array is checked is unspecified.
 
 ```ts
 export declare const upsert: <A>(eqA: Eq<A>) => (x: A) => (ys: readonly A[]) => ReadonlyNonEmptyArray<A>
-```
-
-```hs
-upsert :: Eq a -> a -> Array a -> ReadonlyNonEmptyArray a
 ```
 
 **Example**
@@ -1216,10 +1061,6 @@ Returns a new array without the values present in the first input array.
 export declare const without: <A>(eq: Eq<A>) => (xs: readonly A[]) => Endomorphism<readonly A[]>
 ```
 
-```hs
-without :: Eq a -> Array a -> Endomorphism (Array a)
-```
-
 **Example**
 
 ```ts
@@ -1246,10 +1087,6 @@ input sizes via the `These` type.
 
 ```ts
 export declare const zipAll: <A>(xs: readonly A[]) => <B>(ys: readonly B[]) => readonly These<B, A>[]
-```
-
-```hs
-zipAll :: Array a -> Array b -> Array (These b a)
 ```
 
 **Example**

--- a/docs/modules/ReadonlyRecord.ts.md
+++ b/docs/modules/ReadonlyRecord.ts.md
@@ -87,10 +87,6 @@ denotes.
 export declare const lookupV: <A>(x: Readonly<Record<string, A>>) => (k: string) => Option<A>
 ```
 
-```hs
-lookupV :: Readonly (Record string a) -> string -> Option a
-```
-
 **Example**
 
 ```ts
@@ -119,10 +115,6 @@ export declare const reject: <A>(
 ) => <B extends A>(x: Readonly<Record<string, B>>) => Readonly<Record<string, B>>
 ```
 
-```hs
-reject :: b extends a => Predicate a -> Readonly (Record string b) -> Readonly (Record string b)
-```
-
 **Example**
 
 ```ts
@@ -144,10 +136,6 @@ Get the values from a `Record`.
 
 ```ts
 export declare const values: <A>(x: Readonly<Record<string, A>>) => readonly A[]
-```
-
-```hs
-values :: Readonly (Record string a) -> Array a
 ```
 
 **Example**

--- a/docs/modules/ReadonlyStruct.ts.md
+++ b/docs/modules/ReadonlyStruct.ts.md
@@ -39,10 +39,6 @@ consider defining a semigroup.
 export declare const merge: <A>(x: A) => <B>(y: B) => A & B
 ```
 
-```hs
-merge :: a -> b -> a & b
-```
-
 **Example**
 
 ```ts
@@ -64,10 +60,6 @@ type.
 export declare const omit: <K extends string>(
   ks: readonly K[]
 ) => <V, A extends Readonly<Record<K, V>>>(x: A) => Pick<A, Exclude<keyof A, K>>
-```
-
-```hs
-omit :: k extends string, a extends (Readonly (Record k v)) => Array k -> a -> Pick a (Exclude (keyof a) k)
 ```
 
 **Example**
@@ -94,10 +86,6 @@ export declare const omitFrom: <A>() => <K extends keyof A & string>(
 ) => (x: A) => Pick<A, Exclude<keyof A, K>>
 ```
 
-```hs
-omitFrom :: k extends ((keyof a) & string) => () -> Array k -> a -> Pick a (Exclude (keyof a) k)
-```
-
 **Example**
 
 ```ts
@@ -122,10 +110,6 @@ type.
 export declare const pick: <A, K extends keyof A>(ks: readonly K[]) => (x: A) => Pick<A, K>
 ```
 
-```hs
-pick :: k extends (keyof a) => Array k -> a -> Pick a k
-```
-
 **Example**
 
 ```ts
@@ -147,10 +131,6 @@ Like `pick`, but allows you to specify the input record upfront.
 
 ```ts
 export declare const pickFrom: <A>() => <K extends keyof A>(ks: readonly K[]) => (x: A) => Pick<A, K>
-```
-
-```hs
-pickFrom :: k extends (keyof a) => () -> Array k -> a -> Pick a k
 ```
 
 **Example**
@@ -181,10 +161,6 @@ export declare const renameKey: <I extends string>(
 ) => <A extends MaybePartial<Readonly<Record<I, unknown>>>>(
   x: A
 ) => Readonly<{ [K in keyof A as K extends I ? J : K]: A[K] }>
-```
-
-```hs
-renameKey :: i extends string, j extends string, a extends (MaybePartial (Readonly (Record i unknown))) => i -> j -> a -> Readonly { [k in (keyof a) as k extends i ? j : k]: a[k] }
 ```
 
 **Example**

--- a/docs/modules/Record.ts.md
+++ b/docs/modules/Record.ts.md
@@ -38,10 +38,6 @@ duplicate keys, see instead `invertLast`.
 export declare const invertAll: <A>(f: (x: A) => string) => (x: Record<string, A>) => Record<string, Array<string>>
 ```
 
-```hs
-invertAll :: (a -> string) -> Record string a -> Record string (Array string)
-```
-
 **Example**
 
 ```ts
@@ -65,10 +61,6 @@ lost, see instead `invertAll`.
 export declare const invertLast: <A>(f: (x: A) => string) => (x: Record<string, A>) => Record<string, string>
 ```
 
-```hs
-invertLast :: (a -> string) -> Record string a -> Record string string
-```
-
 **Example**
 
 ```ts
@@ -88,10 +80,6 @@ Like `fp-ts/Record::lookup` but flipped, which the "V" suffix denotes.
 
 ```ts
 export declare const lookupV: <A>(x: Record<string, A>) => (k: string) => Option<A>
-```
-
-```hs
-lookupV :: Record string a -> string -> Option a
 ```
 
 **Example**
@@ -120,10 +108,6 @@ filtering.
 export declare const reject: <A>(f: Predicate<A>) => <B extends A>(x: Record<string, B>) => Record<string, B>
 ```
 
-```hs
-reject :: b extends a => Predicate a -> Record string b -> Record string b
-```
-
 **Example**
 
 ```ts
@@ -145,10 +129,6 @@ Get the values from a `Record`.
 
 ```ts
 export declare const values: <A>(x: Record<string, A>) => A[]
-```
-
-```hs
-values :: Record string a -> Array a
 ```
 
 **Example**

--- a/docs/modules/Show.ts.md
+++ b/docs/modules/Show.ts.md
@@ -35,10 +35,6 @@ functions that require it.
 export declare const Contravariant: Contravariant1<'Show'>
 ```
 
-```hs
-Contravariant :: Contravariant1 "Show"
-```
-
 Added in v0.12.0
 
 ## URI
@@ -49,10 +45,6 @@ Typeclass machinery.
 
 ```ts
 export declare const URI: 'Show'
-```
-
-```hs
-URI :: "Show"
 ```
 
 Added in v0.12.0
@@ -67,10 +59,6 @@ Typeclass machinery.
 export type URI = typeof URI
 ```
 
-```hs
-type URI = typeof URI
-```
-
 Added in v0.12.0
 
 ## contramap
@@ -82,10 +70,6 @@ a `Show<A>` instance.
 
 ```ts
 export declare const contramap: <B, A>(f: (b: B) => A) => (m: Show<A>) => Show<B>
-```
-
-```hs
-contramap :: (b -> a) -> Show a -> Show b
 ```
 
 Added in v0.12.0

--- a/docs/modules/String.ts.md
+++ b/docs/modules/String.ts.md
@@ -66,10 +66,6 @@ Append one string to another.
 export declare const append: (appended: string) => Endomorphism<string>
 ```
 
-```hs
-append :: string -> Endomorphism string
-```
-
 **Example**
 
 ```ts
@@ -100,10 +96,6 @@ If `n` is a float, it will be rounded down to the nearest integer.
 export declare const dropLeft: (n: number) => Endomorphism<string>
 ```
 
-```hs
-dropLeft :: number -> Endomorphism string
-```
-
 **Example**
 
 ```ts
@@ -123,10 +115,6 @@ specified predicate, creating a new string.
 
 ```ts
 export declare const dropLeftWhile: (f: Predicate<string>) => Endomorphism<string>
-```
-
-```hs
-dropLeftWhile :: Predicate string -> Endomorphism string
 ```
 
 **Example**
@@ -159,10 +147,6 @@ If `n` is a float, it will be rounded down to the nearest integer.
 export declare const dropRight: (n: number) => Endomorphism<string>
 ```
 
-```hs
-dropRight :: number -> Endomorphism string
-```
-
 **Example**
 
 ```ts
@@ -182,10 +166,6 @@ which all characters satisfy the specified predicate, creating a new string.
 
 ```ts
 export declare const dropRightWhile: (f: Predicate<string>) => Endomorphism<string>
-```
-
-```hs
-dropRightWhile :: Predicate string -> Endomorphism string
 ```
 
 **Example**
@@ -213,10 +193,6 @@ Convert a number to a string.
 export declare const fromNumber: (x: number) => string
 ```
 
-```hs
-fromNumber :: number -> string
-```
-
 **Example**
 
 ```ts
@@ -235,10 +211,6 @@ Get the first character in a string, or `None` if the string is empty.
 
 ```ts
 export declare const head: (x: string) => Option<string>
-```
-
-```hs
-head :: string -> Option string
 ```
 
 **Example**
@@ -261,10 +233,6 @@ Get all but the last character of a string, or `None` if the string is empty.
 
 ```ts
 export declare const init: (x: string) => Option<string>
-```
-
-```hs
-init :: string -> Option string
 ```
 
 **Example**
@@ -292,10 +260,6 @@ in case of an empty string is unspecified.
 export declare const isAlpha: Predicate<string>
 ```
 
-```hs
-isAlpha :: Predicate string
-```
-
 **Example**
 
 ```ts
@@ -319,10 +283,6 @@ Behaviour in case of an empty string is unspecified.
 export declare const isAlphaNum: Predicate<string>
 ```
 
-```hs
-isAlphaNum :: Predicate string
-```
-
 **Example**
 
 ```ts
@@ -343,10 +303,6 @@ Behaviour in case of an empty string is unspecified.
 
 ```ts
 export declare const isLower: Predicate<string>
-```
-
-```hs
-isLower :: Predicate string
 ```
 
 **Example**
@@ -372,10 +328,6 @@ an empty string is unspecified.
 export declare const isSpace: Predicate<string>
 ```
 
-```hs
-isSpace :: Predicate string
-```
-
 **Example**
 
 ```ts
@@ -397,10 +349,6 @@ Behaviour in case of an empty string is unspecified.
 
 ```ts
 export declare const isUpper: Predicate<string>
-```
-
-```hs
-isUpper :: Predicate string
 ```
 
 **Example**
@@ -425,10 +373,6 @@ Get the last character in a string, or `None` if the string is empty.
 export declare const last: (x: string) => Option<string>
 ```
 
-```hs
-last :: string -> Option string
-```
-
 **Example**
 
 ```ts
@@ -451,10 +395,6 @@ Split a string into substrings using any recognised newline as the separator.
 export declare const lines: (s: string) => ReadonlyNonEmptyArray<string>
 ```
 
-```hs
-lines :: string -> ReadonlyNonEmptyArray string
-```
-
 **Example**
 
 ```ts
@@ -473,10 +413,6 @@ Attempt to access the character at the specified index of a string.
 
 ```ts
 export declare const lookup: (i: number) => (x: string) => Option<string>
-```
-
-```hs
-lookup :: number -> string -> Option string
 ```
 
 **Example**
@@ -499,10 +435,6 @@ Functional wrapper around `String.prototype.match`.
 
 ```ts
 export declare const match: (r: RegExp) => (x: string) => Option<RegExpMatchArray>
-```
-
-```hs
-match :: RegExp -> string -> Option RegExpMatchArray
 ```
 
 **Example**
@@ -533,10 +465,6 @@ If the provided `RegExp` is non-global, the function will return `None`.
 
 ```ts
 export declare const matchAll: (r: RegExp) => (x: string) => Option<NonEmptyArray<RegExpMatchArray>>
-```
-
-```hs
-matchAll :: RegExp -> string -> Option (NonEmptyArray RegExpMatchArray)
 ```
 
 **Example**
@@ -570,10 +498,6 @@ Prepend one string to another.
 export declare const prepend: (prepended: string) => Endomorphism<string>
 ```
 
-```hs
-prepend :: string -> Endomorphism string
-```
-
 **Example**
 
 ```ts
@@ -599,10 +523,6 @@ To use a `RegExp` (with a global flag) instead of a string to match, use
 export declare const replaceAll: (r: string) => (s: string) => Endomorphism<string>
 ```
 
-```hs
-replaceAll :: string -> string -> Endomorphism string
-```
-
 **Example**
 
 ```ts
@@ -621,10 +541,6 @@ Reverse a string.
 
 ```ts
 export declare const reverse: Endomorphism<string>
-```
-
-```hs
-reverse :: Endomorphism string
 ```
 
 **Example**
@@ -648,10 +564,6 @@ Resulting parts can then be handled using fp-ts/Tuple.
 export declare const splitAt: (index: number) => (str: string) => [string, string]
 ```
 
-```hs
-splitAt :: number -> string -> [string, string]
-```
-
 **Example**
 
 ```ts
@@ -671,10 +583,6 @@ same outer value.
 
 ```ts
 export declare const surround: (x: string) => Endomorphism<string>
-```
-
-```hs
-surround :: string -> Endomorphism string
 ```
 
 **Example**
@@ -697,10 +605,6 @@ Get all but the first character of a string, or `None` if the string is empty.
 
 ```ts
 export declare const tail: (x: string) => Option<string>
-```
-
-```hs
-tail :: string -> Option string
 ```
 
 **Example**
@@ -734,10 +638,6 @@ If `n` is a float, it will be rounded down to the nearest integer.
 export declare const takeLeft: (n: number) => Endomorphism<string>
 ```
 
-```hs
-takeLeft :: number -> Endomorphism string
-```
-
 **Example**
 
 ```ts
@@ -757,10 +657,6 @@ specified predicate, creating a new string.
 
 ```ts
 export declare const takeLeftWhile: (f: Predicate<string>) => Endomorphism<string>
-```
-
-```hs
-takeLeftWhile :: Predicate string -> Endomorphism string
 ```
 
 **Example**
@@ -790,10 +686,6 @@ If `n` is a float, it will be rounded down to the nearest integer.
 export declare const takeRight: (n: number) => Endomorphism<string>
 ```
 
-```hs
-takeRight :: number -> Endomorphism string
-```
-
 **Example**
 
 ```ts
@@ -816,10 +708,6 @@ string.
 export declare const takeRightWhile: (f: Predicate<string>) => Endomorphism<string>
 ```
 
-```hs
-takeRightWhile :: Predicate string -> Endomorphism string
-```
-
 **Example**
 
 ```ts
@@ -838,10 +726,6 @@ A functional wrapper around `RegExp.prototype.test`.
 
 ```ts
 export declare const test: (r: RegExp) => Predicate<string>
-```
-
-```hs
-test :: RegExp -> Predicate string
 ```
 
 **Example**
@@ -865,10 +749,6 @@ Remove the end of a string, if it exists.
 
 ```ts
 export declare const unappend: (end: string) => Endomorphism<string>
-```
-
-```hs
-unappend :: string -> Endomorphism string
 ```
 
 **Example**
@@ -898,10 +778,6 @@ a string can be thought of merely as an array of characters.
 export declare const under: (f: Endomorphism<ReadonlyArray<string>>) => Endomorphism<string>
 ```
 
-```hs
-under :: Endomorphism (ReadonlyArray string) -> Endomorphism string
-```
-
 **Example**
 
 ```ts
@@ -925,10 +801,6 @@ Join newline-separated strings together.
 export declare const unlines: (ys: readonly string[]) => string
 ```
 
-```hs
-unlines :: Array string -> string
-```
-
 **Example**
 
 ```ts
@@ -947,10 +819,6 @@ Remove the beginning of a string, if it exists.
 
 ```ts
 export declare const unprepend: (start: string) => Endomorphism<string>
-```
-
-```hs
-unprepend :: string -> Endomorphism string
 ```
 
 **Example**
@@ -975,10 +843,6 @@ Remove the start and end of a string, if they both exist.
 export declare const unsurround: (x: string) => Endomorphism<string>
 ```
 
-```hs
-unsurround :: string -> Endomorphism string
-```
-
 **Example**
 
 ```ts
@@ -1001,10 +865,6 @@ Join whitespace-separated strings together.
 export declare const unwords: (ys: readonly string[]) => string
 ```
 
-```hs
-unwords :: Array string -> string
-```
-
 **Example**
 
 ```ts
@@ -1024,10 +884,6 @@ separator.
 
 ```ts
 export declare const words: (s: string) => ReadonlyNonEmptyArray<string>
-```
-
-```hs
-words :: string -> ReadonlyNonEmptyArray string
 ```
 
 **Example**

--- a/docs/modules/Struct.ts.md
+++ b/docs/modules/Struct.ts.md
@@ -39,10 +39,6 @@ consider defining a semigroup.
 export declare const merge: <A>(x: A) => <B>(y: B) => A & B
 ```
 
-```hs
-merge :: a -> b -> a & b
-```
-
 **Example**
 
 ```ts
@@ -66,10 +62,6 @@ export declare const omit: <K extends string>(
 ) => <V, A extends Record<K, V>>(x: A) => Pick<A, Exclude<keyof A, K>>
 ```
 
-```hs
-omit :: k extends string, a extends (Record k v) => Array k -> a -> Pick a (Exclude (keyof a) k)
-```
-
 **Example**
 
 ```ts
@@ -90,10 +82,6 @@ Like `omit`, but allows you to specify the input record upfront.
 
 ```ts
 export declare const omitFrom: <A>() => <K extends keyof A & string>(ks: K[]) => (x: A) => Pick<A, Exclude<keyof A, K>>
-```
-
-```hs
-omitFrom :: k extends ((keyof a) & string) => () -> Array k -> a -> Pick a (Exclude (keyof a) k)
 ```
 
 **Example**
@@ -120,10 +108,6 @@ type.
 export declare const pick: <A, K extends keyof A>(ks: K[]) => (x: A) => Pick<A, K>
 ```
 
-```hs
-pick :: k extends (keyof a) => Array k -> a -> Pick a k
-```
-
 **Example**
 
 ```ts
@@ -145,10 +129,6 @@ Like `pick`, but allows you to specify the input record upfront.
 
 ```ts
 export declare const pickFrom: <A>() => <K extends keyof A>(ks: K[]) => (x: A) => Pick<A, K>
-```
-
-```hs
-pickFrom :: k extends (keyof a) => () -> Array k -> a -> Pick a k
 ```
 
 **Example**
@@ -175,10 +155,6 @@ exists, the old key will be overwritten. Optionality is preserved.
 export declare const renameKey: <I extends string>(
   oldK: I
 ) => <J extends string>(newK: J) => <A extends MaybePartial<Record<I, unknown>>>(x: A) => RenameKey<A, I, J>
-```
-
-```hs
-renameKey :: i extends string, j extends string, a extends (MaybePartial (Record i unknown)) => i -> j -> a -> RenameKey a i j
 ```
 
 **Example**

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -40,10 +40,6 @@ took for the task to complete. The task otherwise operates as per usual.
 export declare const elapsed: (f: (n: Milliseconds) => IO<void>) => <A>(x: Task<A>) => Task<A>
 ```
 
-```hs
-elapsed :: (Milliseconds -> IO void) -> Task a -> Task a
-```
-
 **Example**
 
 ```ts
@@ -75,10 +71,6 @@ function application and composition pipelines.
 export declare const execute: <A>(x: Task<A>) => Promise<A>
 ```
 
-```hs
-execute :: Task a -> Promise a
-```
-
 **Example**
 
 ```ts
@@ -102,10 +94,6 @@ Sequence an array of tasks, ignoring the results.
 export declare const sequenceArray_: <A>(xs: readonly Task<A>[]) => Task<void>
 ```
 
-```hs
-sequenceArray_ :: Array (Task a) -> Task void
-```
-
 Added in v0.15.0
 
 ## sequenceSeqArray\_
@@ -116,10 +104,6 @@ Sequentially sequence an array of tasks, ignoring the results.
 
 ```ts
 export declare const sequenceSeqArray_: <A>(xs: readonly Task<A>[]) => Task<void>
-```
-
-```hs
-sequenceSeqArray_ :: Array (Task a) -> Task void
 ```
 
 Added in v0.15.0
@@ -135,10 +119,6 @@ resolves with void. Can also be useful with async/await (`await sleep(n)()`).
 
 ```ts
 export declare const sleep: (n: Milliseconds) => Task<void>
-```
-
-```hs
-sleep :: Milliseconds -> Task void
 ```
 
 **Example**
@@ -185,10 +165,6 @@ Map to and sequence an array of tasks, ignoring the results.
 export declare const traverseArray_: <A, B>(f: (x: A) => Task<B>) => (xs: readonly A[]) => Task<void>
 ```
 
-```hs
-traverseArray_ :: (a -> Task b) -> Array a -> Task void
-```
-
 Added in v0.15.0
 
 ## traverseSeqArray\_
@@ -201,10 +177,6 @@ Sequentially map to and sequence an array of tasks, ignoring the results.
 export declare const traverseSeqArray_: <A, B>(f: (x: A) => Task<B>) => (xs: readonly A[]) => Task<void>
 ```
 
-```hs
-traverseSeqArray_ :: (a -> Task b) -> Array a -> Task void
-```
-
 Added in v0.15.0
 
 ## unless
@@ -215,10 +187,6 @@ The reverse of `when`.
 
 ```ts
 export declare const unless: (x: boolean) => Endomorphism<Task<void>>
-```
-
-```hs
-unless :: boolean -> Endomorphism (Task void)
 ```
 
 **Example**
@@ -251,10 +219,6 @@ logging.
 
 ```ts
 export declare const when: (x: boolean) => Endomorphism<Task<void>>
-```
-
-```hs
-when :: boolean -> Endomorphism (Task void)
 ```
 
 **Example**

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -37,10 +37,6 @@ Apply a function to both elements of an `TaskEither`.
 export declare const mapBoth: <A, B>(f: (x: A) => B) => (xs: TaskEither<A, A>) => TaskEither<B, B>
 ```
 
-```hs
-mapBoth :: (a -> b) -> TaskEither a a -> TaskEither b b
-```
-
 **Example**
 
 ```ts
@@ -71,10 +67,6 @@ Sequence an array of fallible tasks, ignoring the results.
 export declare const sequenceArray_: <E, A>(xs: readonly TaskEither<E, A>[]) => TaskEither<E, void>
 ```
 
-```hs
-sequenceArray_ :: Array (TaskEither e a) -> TaskEither e void
-```
-
 Added in v0.15.0
 
 ## sequenceSeqArray\_
@@ -85,10 +77,6 @@ Sequentially sequence an array of fallible tasks, ignoring the results.
 
 ```ts
 export declare const sequenceSeqArray_: <E, A>(xs: readonly TaskEither<E, A>[]) => TaskEither<E, void>
-```
-
-```hs
-sequenceSeqArray_ :: Array (TaskEither e a) -> TaskEither e void
 ```
 
 Added in v0.15.0
@@ -103,10 +91,6 @@ Map to and sequence an array of fallible tasks, ignoring the results.
 export declare const traverseArray_: <E, A, B>(
   f: (x: A) => TaskEither<E, B>
 ) => (xs: readonly A[]) => TaskEither<E, void>
-```
-
-```hs
-traverseArray_ :: (a -> TaskEither e b) -> Array a -> TaskEither e void
 ```
 
 Added in v0.15.0
@@ -124,10 +108,6 @@ export declare const traverseSeqArray_: <E, A, B>(
 ) => (xs: readonly A[]) => TaskEither<E, void>
 ```
 
-```hs
-traverseSeqArray_ :: (a -> TaskEither e b) -> Array a -> TaskEither e void
-```
-
 Added in v0.15.0
 
 ## unsafeUnwrap
@@ -139,10 +119,6 @@ value of `Left` if `Left`.
 
 ```ts
 export declare const unsafeUnwrap: <A>(x: TaskEither<unknown, A>) => Promise<A>
-```
-
-```hs
-unsafeUnwrap :: TaskEither unknown a -> Promise a
 ```
 
 **Example**
@@ -167,10 +143,6 @@ Unwrap the promise from within a `TaskEither`, throwing the inner value of
 
 ```ts
 export declare const unsafeUnwrapLeft: <E>(x: TaskEither<E, unknown>) => Promise<E>
-```
-
-```hs
-unsafeUnwrapLeft :: TaskEither e unknown -> Promise e
 ```
 
 **Example**

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -31,10 +31,6 @@ Unwrap the promise from within a `TaskOption`, rejecting if `None`.
 export declare const unsafeUnwrap: <A>(x: TaskOption<A>) => Promise<A>
 ```
 
-```hs
-unsafeUnwrap :: TaskOption a -> Promise a
-```
-
 **Example**
 
 ```ts

--- a/docs/modules/Tuple.ts.md
+++ b/docs/modules/Tuple.ts.md
@@ -41,10 +41,6 @@ having to repeat yourself or use `as const`.
 export declare const create: <A, B>(xs: [A, B]) => [A, B]
 ```
 
-```hs
-create :: [a, b] -> [a, b]
-```
-
 **Example**
 
 ```ts
@@ -63,10 +59,6 @@ Duplicate a value into a tuple.
 
 ```ts
 export declare const dup: <A>(x: A) => [A, A]
-```
-
-```hs
-dup :: a -> [a, a]
 ```
 
 **Example**
@@ -88,10 +80,6 @@ variadic version, consider `fork` in `Function`.
 
 ```ts
 export declare const fanout: <A, B>(f: (x: A) => B) => <C>(g: (x: A) => C) => (x: A) => [B, C]
-```
-
-```hs
-fanout :: (a -> b) -> (a -> c) -> a -> [b, c]
 ```
 
 **Example**
@@ -116,10 +104,6 @@ Apply a function to both elements of a tuple.
 
 ```ts
 export declare const mapBoth: <A, B>(f: (x: A) => B) => (xs: [A, A]) => [B, B]
-```
-
-```hs
-mapBoth :: (a -> b) -> [a, a] -> [b, b]
 ```
 
 **Example**
@@ -147,10 +131,6 @@ Apply a function, collecting the output alongside the input. A dual to
 export declare const toFst: <A, B>(f: (x: A) => B) => (x: A) => [B, A]
 ```
 
-```hs
-toFst :: (a -> b) -> a -> [b, a]
-```
-
 **Example**
 
 ```ts
@@ -171,10 +151,6 @@ Apply a function, collecting the input alongside the output. A dual to
 
 ```ts
 export declare const toSnd: <A, B>(f: (x: A) => B) => (x: A) => [A, B]
-```
-
-```hs
-toSnd :: (a -> b) -> a -> [a, b]
 ```
 
 **Example**
@@ -212,15 +188,6 @@ export declare function traverseToFst<F extends URIS>(
   F: Functor1<F>
 ): <A, B>(g: (x: A) => Kind<F, B>) => (x: A) => Kind<F, [B, A]>
 export declare function traverseToFst<F>(F: Functor<F>): <A, B>(g: (x: A) => HKT<F, B>) => (x: A) => HKT<F, [B, A]>
-```
-
-```hs
-traverseToFst :: f extends URIS4 => Functor4 f -> (a -> Kind4 f s r e b) -> a -> Kind4 f s r e [b, a]
-traverseToFst :: f extends URIS3 => ((Functor3 f) -> (a -> Kind3 f r e b) -> a -> Kind3 f r e [b, a])
-traverseToFst :: f extends URIS2 => ((Functor2 f) -> (a -> Kind2 f e b) -> a -> Kind2 f e [b, a])
-traverseToFst :: f extends URIS2 => ((Functor2C f e) -> (a -> Kind2 f e b) -> a -> Kind2 f e [b, a])
-traverseToFst :: f extends URIS => ((Functor1 f) -> (a -> Kind f b) -> a -> Kind f [b, a])
-traverseToFst :: ((Functor f) -> (a -> HKT f b) -> a -> HKT f [b, a])
 ```
 
 **Example**
@@ -266,15 +233,6 @@ export declare function traverseToSnd<F extends URIS>(
 export declare function traverseToSnd<F>(F: Functor<F>): <A, B>(g: (x: A) => HKT<F, B>) => (x: A) => HKT<F, [A, B]>
 ```
 
-```hs
-traverseToSnd :: f extends URIS4 => Functor4 f -> (a -> Kind4 f s r e b) -> a -> Kind4 f s r e [a, b]
-traverseToSnd :: f extends URIS3 => ((Functor3 f) -> (a -> Kind3 f r e b) -> a -> Kind3 f r e [a, b])
-traverseToSnd :: f extends URIS2 => ((Functor2 f) -> (a -> Kind2 f e b) -> a -> Kind2 f e [a, b])
-traverseToSnd :: f extends URIS2 => ((Functor2C f e) -> (a -> Kind2 f e b) -> a -> Kind2 f e [a, b])
-traverseToSnd :: f extends URIS => ((Functor1 f) -> (a -> Kind f b) -> a -> Kind f [a, b])
-traverseToSnd :: ((Functor f) -> (a -> HKT f b) -> a -> HKT f [a, b])
-```
-
 **Example**
 
 ```ts
@@ -303,10 +261,6 @@ tuple sections.
 export declare const withFst: <A>(x: A) => <B>(y: B) => [A, B]
 ```
 
-```hs
-withFst :: a -> b -> [a, b]
-```
-
 **Example**
 
 ```ts
@@ -327,10 +281,6 @@ tuple sections.
 
 ```ts
 export declare const withSnd: <A>(x: A) => <B>(y: B) => [B, A]
-```
-
-```hs
-withSnd :: a -> b -> [b, a]
 ```
 
 **Example**

--- a/docs/modules/URL.ts.md
+++ b/docs/modules/URL.ts.md
@@ -34,10 +34,6 @@ Refine a foreign value to `URL`.
 export declare const isURL: Refinement<unknown, URL>
 ```
 
-```hs
-isURL :: Refinement unknown URL
-```
-
 **Example**
 
 ```ts
@@ -57,10 +53,6 @@ Safely parse a `URL`.
 
 ```ts
 export declare const parse: <E>(f: (e: TypeError) => E) => (x: string) => Either<E, URL>
-```
-
-```hs
-parse :: (TypeError -> e) -> string -> Either e URL
 ```
 
 **Example**
@@ -88,10 +80,6 @@ Safely parse a `URL`, returning an `Option`.
 export declare const parseO: (href: string) => Option<URL>
 ```
 
-```hs
-parseO :: string -> Option URL
-```
-
 **Example**
 
 ```ts
@@ -112,10 +100,6 @@ Unsafely parse a `URL`, throwing on failure.
 
 ```ts
 export declare const unsafeParse: (x: string) => URL
-```
-
-```hs
-unsafeParse :: string -> URL
 ```
 
 **Example**

--- a/docs/modules/URLSearchParams.ts.md
+++ b/docs/modules/URLSearchParams.ts.md
@@ -39,10 +39,6 @@ Clone a `URLSearchParams`.
 export declare const clone: (x: URLSearchParams) => URLSearchParams
 ```
 
-```hs
-clone :: URLSearchParams -> URLSearchParams
-```
-
 **Example**
 
 ```ts
@@ -66,10 +62,6 @@ An empty `URLSearchParams`.
 export declare const empty: URLSearchParams
 ```
 
-```hs
-empty :: URLSearchParams
-```
-
 **Example**
 
 ```ts
@@ -88,10 +80,6 @@ Parse a `URLSearchParams` from a record.
 
 ```ts
 export declare const fromRecord: (x: Record<string, string>) => URLSearchParams
-```
-
-```hs
-fromRecord :: Record string string -> URLSearchParams
 ```
 
 **Example**
@@ -116,10 +104,6 @@ Parse a `URLSearchParams` from a string.
 export declare const fromString: (x: string) => URLSearchParams
 ```
 
-```hs
-fromString :: string -> URLSearchParams
-```
-
 **Example**
 
 ```ts
@@ -140,10 +124,6 @@ Parse a `URLSearchParams` from an array of tuples.
 
 ```ts
 export declare const fromTuples: (x: Array<[string, string]>) => URLSearchParams
-```
-
-```hs
-fromTuples :: Array [string, string] -> URLSearchParams
 ```
 
 **Example**
@@ -171,10 +151,6 @@ Attempt to get a URL parameter from a `URLSearchParams`.
 export declare const getParam: (k: string) => (ps: URLSearchParams) => Option<string>
 ```
 
-```hs
-getParam :: string -> URLSearchParams -> Option string
-```
-
 **Example**
 
 ```ts
@@ -199,10 +175,6 @@ Refine a foreign value to `URLSearchParams`.
 export declare const isURLSearchParams: Refinement<unknown, URLSearchParams>
 ```
 
-```hs
-isURLSearchParams :: Refinement unknown URLSearchParams
-```
-
 **Example**
 
 ```ts
@@ -224,10 +196,6 @@ Set a URL parameter in a `URLSearchParams`. This does not mutate the input.
 
 ```ts
 export declare const setParam: (k: string) => (v: string) => (x: URLSearchParams) => URLSearchParams
-```
-
-```hs
-setParam :: string -> string -> URLSearchParams -> URLSearchParams
 ```
 
 **Example**

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -72,10 +72,6 @@ A re-export of the `fp-ts-std/Alternative` module.
 export declare const alternative: typeof alternative
 ```
 
-```hs
-alternative :: typeof alternative
-```
-
 Added in v0.13.0
 
 ## applicative
@@ -86,10 +82,6 @@ A re-export of the `fp-ts-std/Applicative` module.
 
 ```ts
 export declare const applicative: typeof applicative
-```
-
-```hs
-applicative :: typeof applicative
 ```
 
 Added in v0.12.0
@@ -104,10 +96,6 @@ A re-export of the `fp-ts-std/Array` module.
 export declare const array: typeof array
 ```
 
-```hs
-array :: typeof array
-```
-
 Added in v0.5.1
 
 ## bifunctor
@@ -118,10 +106,6 @@ A re-export of the `fp-ts-std/Bifunctor` module.
 
 ```ts
 export declare const bifunctor: typeof bifunctor
-```
-
-```hs
-bifunctor :: typeof bifunctor
 ```
 
 Added in v0.14.0
@@ -136,10 +120,6 @@ A re-export of the `fp-ts-std/Boolean` module.
 export declare const boolean: typeof boolean
 ```
 
-```hs
-boolean :: typeof boolean
-```
-
 Added in v0.5.1
 
 ## date
@@ -150,10 +130,6 @@ A re-export of the `fp-ts-std/Date` module.
 
 ```ts
 export declare const date: typeof date
-```
-
-```hs
-date :: typeof date
 ```
 
 Added in v0.5.1
@@ -168,10 +144,6 @@ A re-export of the `fp-ts-std/Debug` module.
 export declare const debug: typeof debug
 ```
 
-```hs
-debug :: typeof debug
-```
-
 Added in v0.8.0
 
 ## dom
@@ -182,10 +154,6 @@ A re-export of the `fp-ts-std/DOM` module.
 
 ```ts
 export declare const dom: typeof dom
-```
-
-```hs
-dom :: typeof dom
 ```
 
 Added in v0.10.0
@@ -201,10 +169,6 @@ A re-export of the `fp-ts-std/Either` module.
 export declare const either: typeof either
 ```
 
-```hs
-either :: typeof either
-```
-
 Added in v0.5.1
 
 ## env
@@ -215,10 +179,6 @@ A re-export of the `fp-ts-std/Env` module.
 
 ```ts
 export declare const env: typeof env
-```
-
-```hs
-env :: typeof env
 ```
 
 Added in v0.12.0
@@ -233,10 +193,6 @@ A re-export of the `fp-ts-std/Function` module.
 export declare const function: typeof function_
 ```
 
-```hs
-function :: typeof function_
-```
-
 Added in v0.5.1
 
 ## io
@@ -247,10 +203,6 @@ A re-export of the `fp-ts-std/IO` module.
 
 ```ts
 export declare const io: typeof io
-```
-
-```hs
-io :: typeof io
 ```
 
 Added in v0.8.0
@@ -265,10 +217,6 @@ A re-export of the `fp-ts-std/IOEither` module.
 export declare const ioEither: typeof ioEither
 ```
 
-```hs
-ioEither :: typeof ioEither
-```
-
 Added in v0.15.0
 
 ## isomorphism
@@ -279,10 +227,6 @@ A re-export of the `fp-ts-std/Isomorphism` module.
 
 ```ts
 export declare const isomorphism: typeof isomorphism
-```
-
-```hs
-isomorphism :: typeof isomorphism
 ```
 
 Added in v0.15.0
@@ -297,10 +241,6 @@ A re-export of the `fp-ts-std/JSON` module.
 export declare const json: typeof json
 ```
 
-```hs
-json :: typeof json
-```
-
 Added in v0.5.1
 
 ## lazy
@@ -311,10 +251,6 @@ A re-export of the `fp-ts-std/Lazy` module.
 
 ```ts
 export declare const lazy: typeof lazy
-```
-
-```hs
-lazy :: typeof lazy
 ```
 
 Added in v0.12.0
@@ -329,10 +265,6 @@ A re-export of the `fp-ts-std/Monad` module.
 export declare const monad: typeof monad
 ```
 
-```hs
-monad :: typeof monad
-```
-
 Added in v0.15.0
 
 ## monoid
@@ -343,10 +275,6 @@ A re-export of the `fp-ts-std/Monoid` module.
 
 ```ts
 export declare const monoid: typeof monoid
-```
-
-```hs
-monoid :: typeof monoid
 ```
 
 Added in v0.12.0
@@ -361,10 +289,6 @@ A re-export of the `fp-ts-std/Number` module.
 export declare const newtype: typeof newtype
 ```
 
-```hs
-newtype :: typeof newtype
-```
-
 Added in v0.15.0
 
 ## nonEmptyString
@@ -375,10 +299,6 @@ A re-export of the `fp-ts-std/NonEmptyString` module.
 
 ```ts
 export declare const nonEmptyString: typeof nonEmptyString
-```
-
-```hs
-nonEmptyString :: typeof nonEmptyString
 ```
 
 Added in v0.15.0
@@ -393,10 +313,6 @@ A re-export of the `fp-ts-std/Number` module.
 export declare const number: typeof number
 ```
 
-```hs
-number :: typeof number
-```
-
 Added in v0.5.1
 
 ## option
@@ -407,10 +323,6 @@ A re-export of the `fp-ts-std/Option` module.
 
 ```ts
 export declare const option: typeof option
-```
-
-```hs
-option :: typeof option
 ```
 
 Added in v0.5.1
@@ -425,10 +337,6 @@ A re-export of the `fp-ts-std/Ordering` module.
 export declare const ordering: typeof ordering
 ```
 
-```hs
-ordering :: typeof ordering
-```
-
 Added in v0.12.0
 
 ## predicate
@@ -439,10 +347,6 @@ A re-export of the `fp-ts-std/Predicate` module.
 
 ```ts
 export declare const predicate: typeof predicate
-```
-
-```hs
-predicate :: typeof predicate
 ```
 
 Added in v0.12.0
@@ -457,10 +361,6 @@ A re-export of the `fp-ts-std/Random` module.
 export declare const random: typeof random
 ```
 
-```hs
-random :: typeof random
-```
-
 Added in v0.15.0
 
 ## reader
@@ -471,10 +371,6 @@ A re-export of the `fp-ts-std/Reader` module.
 
 ```ts
 export declare const reader: typeof reader
-```
-
-```hs
-reader :: typeof reader
 ```
 
 Added in v0.15.0
@@ -489,10 +385,6 @@ A re-export of the `fp-ts-std/ReaderEither` module.
 export declare const readerEither: typeof readerEither
 ```
 
-```hs
-readerEither :: typeof readerEither
-```
-
 Added in v0.15.0
 
 ## readerTask
@@ -503,10 +395,6 @@ A re-export of the `fp-ts-std/ReaderTask` module.
 
 ```ts
 export declare const readerTask: typeof readerTask
-```
-
-```hs
-readerTask :: typeof readerTask
 ```
 
 Added in v0.15.0
@@ -521,10 +409,6 @@ A re-export of the `fp-ts-std/ReaderTaskEither` module.
 export declare const readerTaskEither: typeof readerTaskEither
 ```
 
-```hs
-readerTaskEither :: typeof readerTaskEither
-```
-
 Added in v0.15.0
 
 ## readonlyArray
@@ -535,10 +419,6 @@ A re-export of the `fp-ts-std/ReadonlyArray` module.
 
 ```ts
 export declare const readonlyArray: typeof readonlyArray
-```
-
-```hs
-readonlyArray :: typeof readonlyArray
 ```
 
 Added in v0.10.0
@@ -553,10 +433,6 @@ A re-export of the `fp-ts-std/ReadonlyRecord` module.
 export declare const readonlyRecord: typeof readonlyRecord
 ```
 
-```hs
-readonlyRecord :: typeof readonlyRecord
-```
-
 Added in v0.10.0
 
 ## readonlyStruct
@@ -567,10 +443,6 @@ A re-export of the `fp-ts-std/ReadonlyStruct` module.
 
 ```ts
 export declare const readonlyStruct: typeof readonlyStruct
-```
-
-```hs
-readonlyStruct :: typeof readonlyStruct
 ```
 
 Added in v0.14.0
@@ -585,10 +457,6 @@ A re-export of the `fp-ts-std/Record` module.
 export declare const record: typeof record
 ```
 
-```hs
-record :: typeof record
-```
-
 Added in v0.5.1
 
 ## show
@@ -599,10 +467,6 @@ A re-export of the `fp-ts-std/Show` module.
 
 ```ts
 export declare const show: typeof show
-```
-
-```hs
-show :: typeof show
 ```
 
 Added in v0.12.0
@@ -617,10 +481,6 @@ A re-export of the `fp-ts-std/String` module.
 export declare const string: typeof string
 ```
 
-```hs
-string :: typeof string
-```
-
 Added in v0.5.1
 
 ## struct
@@ -631,10 +491,6 @@ A re-export of the `fp-ts-std/Struct` module.
 
 ```ts
 export declare const struct: typeof struct
-```
-
-```hs
-struct :: typeof struct
 ```
 
 Added in v0.14.0
@@ -649,10 +505,6 @@ A re-export of the `fp-ts-std/Task` module.
 export declare const task: typeof task
 ```
 
-```hs
-task :: typeof task
-```
-
 Added in v0.5.1
 
 ## taskEither
@@ -663,10 +515,6 @@ A re-export of the `fp-ts-std/TaskEither` module.
 
 ```ts
 export declare const taskEither: typeof taskEither
-```
-
-```hs
-taskEither :: typeof taskEither
 ```
 
 Added in v0.12.0
@@ -681,10 +529,6 @@ A re-export of the `fp-ts-std/TaskOption` module.
 export declare const taskOption: typeof taskOption
 ```
 
-```hs
-taskOption :: typeof taskOption
-```
-
 Added in v0.12.0
 
 ## tuple
@@ -695,10 +539,6 @@ A re-export of the `fp-ts-std/Tuple` module.
 
 ```ts
 export declare const tuple: typeof tuple
-```
-
-```hs
-tuple :: typeof tuple
 ```
 
 Added in v0.12.0
@@ -713,10 +553,6 @@ A re-export of the `fp-ts-std/URL` module.
 export declare const url: typeof url
 ```
 
-```hs
-url :: typeof url
-```
-
 Added in v0.5.1
 
 ## urlSearchParams
@@ -727,10 +563,6 @@ A re-export of the `fp-ts-std/URLSearchParams` module.
 
 ```ts
 export declare const urlSearchParams: typeof urlSearchParams
-```
-
-```hs
-urlSearchParams :: typeof urlSearchParams
 ```
 
 Added in v0.5.1


### PR DESCRIPTION
So I gave it a try at implementing a way of removing an event listener after adding it to a node.

A problem I ended up facing was that by definition, you can only remove an event listener from a `node` _if_ you keep around a reference to the function that you added to said `node`.

Given that the wrapper around `DOM.addEventListener` expects a `(e: Event) => IO<void>` as the event listener to be mounted on the node but the underlying DOM implementation of `addEventListener` expects a `(e: Event) => void` before mounting the listener to the node, we first have to turn the function inside-out and execute the `IO`... but this means that the listener we end up mounting on the node is actually a different function from what had originally been passed to our `DOM.addEventListener`!

Practically speaking, this means that:
```ts
declare const someFunction: (e: Event) => IO<void>

window.addEventListener("click", _ => someFunction(_)())
window.removeEventListener("click", _ => someFunction(_)()) 
/* ^-- this will never work, the function mounted on window click is NOT someFunction */
``` 

The cleanest way I found of dealing with this problem was making it so that `DOM.addEventListener` also returns an `IO<void>` to be used to remove that same event listener.
This lets me create a private reference to the "unwrapped" `(e: Event) => IO<void>` and thus have a consistent way of creating a`removeEventListener` that will actually work.

I also thought about possibly returning just the "private" listener as `IO<(e: Event) => void>` but I felt like this type definition didn't really make much sense...

I guess that we could also return some sort of `State` to keep around all the "right" reference to the listeners that are actually being mounted on a node, but that might be more trouble than it is worth it I guess?