### PR TITLE
changes DOM.addEventListener to returning a cleanup function

### DIFF
--- a/src/DOM.ts
+++ b/src/DOM.ts
@@ -15,7 +15,6 @@ import { NonEmptyArray } from "fp-ts/NonEmptyArray"
 import * as NEA from "fp-ts/NonEmptyArray"
 import { flow, pipe } from "fp-ts/function"
 import { invoke } from "./Function"
-
 /**
  * Convert a `NodeList` into an `Array`.
  *
@@ -241,8 +240,12 @@ export const setTextContent =
     y.textContent = x
   }
 
+type EventTarget = keyof WindowEventMap
+type EventListener = (e: Event) => IO<void>
+type EventListenerCleanup = IO<void>
 /**
  * Adds an event listener to a node.
+ * Returns a cleanup function for removing the event listener.
  *
  * @example
  * import { JSDOM } from 'jsdom'
@@ -258,18 +261,27 @@ export const setTextContent =
  * el.click()
  * assert.strictEqual(clicks, 0)
  *
- * listen()
+ * const cleanupClickHandler = listen()
  * el.click()
  * assert.strictEqual(clicks, 1)
  *
  * el.click()
  * assert.strictEqual(clicks, 2)
  *
+ * cleanupClickHandler()
+ * el.click()
+ * assert.strictEqual(clicks, 2)
+ *
  * @since 0.12.0
  */
+
 export const addEventListener =
-  (type: string) =>
-  (f: (evt: Event) => IO<void>) =>
-  (x: Node): IO<void> =>
-  () =>
-    pipe(x, invoke("addEventListener")([type, evt => f(evt)()]))
+  (type: EventTarget) =>
+  (listener: EventListener) =>
+  (el: Node | Window) =>
+  (): EventListenerCleanup => {
+    const _listener = (e: Event) => listener(e)()
+    // eslint-disable-next-line functional/no-expression-statement
+    pipe(el, invoke("addEventListener")([type, _listener]))
+    return () => pipe(el, invoke("removeEventListener")([type, _listener]))
+  }

--- a/test/DOM.ts
+++ b/test/DOM.ts
@@ -7,6 +7,7 @@ import {
   appendChild,
   emptyChildren,
   addEventListener,
+  addEventListener_,
   getTextContent,
   setTextContent,
 } from "../src/DOM"
@@ -327,6 +328,44 @@ describe("DOM", () => {
       // eslint-disable-next-line functional/no-expression-statement
       findElement().click()
       expect(mockSomeEventFunction).toBeCalledTimes(2)
+    })
+  })
+
+  describe("addEventListener_", () => {
+    const f = addEventListener_
+
+    it("calls callback on event trigger", () => {
+      const {
+        window: { document },
+      } = new JSDOM("<div></div>")
+
+      const parent = pipe(
+        querySelector("div")(document),
+        IO.map(unsafeUnwrap),
+        IO.map(el => el as HTMLElement),
+      )
+
+      // eslint-disable-next-line functional/no-let
+      let clicks = 0
+      expect(clicks).toBe(0)
+
+      // eslint-disable-next-line functional/no-expression-statement
+      parent().click()
+      expect(clicks).toBe(0)
+
+      // eslint-disable-next-line functional/no-expression-statement
+      f("click")(() => () => {
+        // eslint-disable-next-line functional/no-expression-statement
+        clicks++
+      })(parent())()
+
+      // eslint-disable-next-line functional/no-expression-statement
+      parent().click()
+      expect(clicks).toBe(1)
+
+      // eslint-disable-next-line functional/no-expression-statement
+      parent().click()
+      expect(clicks).toBe(2)
     })
   })
 


### PR DESCRIPTION
So I gave it a try at implementing a way of removing an event listener after adding it to a node.

A problem I ended up facing was that by definition, you can only remove an event listener from a `node` _if_ you keep around a reference to the function that you added to said `node`.

Given that the wrapper around `DOM.addEventListener` expects a `(e: Event) => IO<void>` as the event listener to be mounted on the node but the underlying DOM implementation of `addEventListener` expects a `(e: Event) => void` before mounting the listener to the node, we first have to turn the function inside-out and execute the `IO`... but this means that the listener we end up mounting on the node is actually a different function from what had originally been passed to our `DOM.addEventListener`!

Practically speaking, this means that:
```ts
declare const someFunction: (e: Event) => IO<void>

window.addEventListener("click", _ => someFunction(_)())
window.removeEventListener("click", _ => someFunction(_)()) 
/* ^-- this will never work, the function mounted on window click is NOT someFunction */
``` 

The cleanest way I found of dealing with this problem was making it so that `DOM.addEventListener` also returns an `IO<void>` to be used to remove that same event listener.
This lets me create a private reference to the "unwrapped" `(e: Event) => IO<void>` and thus have a consistent way of creating a`removeEventListener` that will actually work.

I also thought about returning just the "private" listener as `IO<(e: Event) => void>` and then having a `removeEventListener :: (type: EventTarget) => (listener: IO<(e: Event) => void>) => (el: Node | Window): IO<void>` but I felt like this type definition didn't really make much sense...

I guess that it would also be possible return some sort of `State` to keep around all the "right" reference to the listeners that are actually being mounted on a node, but that might be more trouble than it is worth it?