### PR TITLE
Make `fromString` work with all numbers, add `integerFromString`

### DIFF
--- a/src/Number.ts
+++ b/src/Number.ts
@@ -60,13 +60,17 @@ export const fromStringWithRadix =
  * import { some, none } from 'fp-ts/Option'
  *
  * assert.deepStrictEqual(fromString('3'), some(3))
- * assert.deepStrictEqual(fromString('abc'), none)
+ * assert.deepStrictEqual(fromString('3.3'), some(3.3))
+ * assert.deepStrictEqual(fromString('0xF'), some(15))
+ * assert.deepStrictEqual(fromString('xyz'), none)
  *
  * @category 3 Functions
  * @since 0.1.0
  */
-export const fromString: (string: string) => Option<number> =
-  fromStringWithRadix(10)
+export const fromString: (string: string) => Option<number> = flow(
+  Number,
+  O.fromPredicate(isValid),
+)
 
 /**
  * Convert a string to a floating point number.
@@ -85,6 +89,23 @@ export const floatFromString: (x: string) => Option<number> = flow(
   Number.parseFloat,
   O.fromPredicate(isValid),
 )
+
+/**
+ * Convert a string to an integer.
+ *
+ * @example
+ * import { integerFromString } from 'fp-ts-std/Number'
+ * import { some, none } from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(integerFromString('3'), some(3))
+ * assert.deepStrictEqual(integerFromString('3.3'), some(3))
+ * assert.deepStrictEqual(integerFromString('abc'), none)
+ *
+ * @category 3 Functions
+ * @since 0.18.0
+ */
+export const integerFromString: (string: string) => Option<number> =
+  fromStringWithRadix(10)
 
 /**
  * Increment a number.

--- a/test/Number.ts
+++ b/test/Number.ts
@@ -11,6 +11,7 @@ import {
   negate,
   fromString,
   floatFromString,
+  integerFromString,
   fromStringWithRadix,
   isFinite,
   toFinite,
@@ -104,8 +105,17 @@ describe("Number", () => {
       expect(f("abc")).toBe(O.none)
     })
 
-    it("returns some for integer", () => {
+    it("returns some(3) for '3'", () => {
       expect(f("3")).toStrictEqual(O.some(3))
+      fc.assert(
+        fc.property(fc.integer(), x =>
+          expect(f(fromNumber(x))).toStrictEqual(O.some(x)),
+        ),
+      )
+    })
+
+    it("returns some(3.3) for '3.3'", () => {
+      expect(f("3.3")).toStrictEqual(O.some(3.3))
       fc.assert(
         fc.property(fc.integer(), x =>
           expect(f(fromNumber(x))).toStrictEqual(O.some(x)),
@@ -133,6 +143,32 @@ describe("Number", () => {
         fc.property(
           fc.float({ noNaN: true }).filter(Pred.not(isNegativeZero)),
           x => expect(f(fromNumber(x))).toStrictEqual(O.some(x)),
+        ),
+      )
+    })
+  })
+
+  describe("integerFromString", () => {
+    const f = integerFromString
+
+    it("returns none for non-number", () => {
+      expect(f("abc")).toBe(O.none)
+    })
+
+    it("returns some(3) for '3'", () => {
+      expect(f("3")).toStrictEqual(O.some(3))
+      fc.assert(
+        fc.property(fc.integer(), x =>
+          expect(f(fromNumber(x))).toStrictEqual(O.some(x)),
+        ),
+      )
+    })
+
+    it("returns some(3) for '3.3'", () => {
+      expect(f("3.3")).toStrictEqual(O.some(3))
+      fc.assert(
+        fc.property(fc.integer(), x =>
+          expect(f(fromNumber(x))).toStrictEqual(O.some(x)),
         ),
       )
     })


### PR DESCRIPTION
Resolves #196 

I added `@since 0.18.0` tags for the new methods, let me know if that's the right approach.

When I ran `yarn docs-ts`, it seemed to delete a few code blocks from each generated file. I left those changes out, but please advise. 

Also, I noticed this is the first time something may be deprecated in this library. I followed the way fp-ts deprecates things.

Hope I didn't miss anything. Thanks!